### PR TITLE
feat: add uv to PATH when creating terminal

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,13 +22,12 @@ jobs:
 
       - name: Download uv
         run: |
-          mkdir bin
+          mkdir temp
+          mkdir -p ./assets/bin
           curl -L https://github.com/astral-sh/uv/releases/download/${{ env.UV_VERSION }}/uv-x86_64-unknown-linux-gnu.tar.gz -o uv.tar.gz
-          tar -xzf uv.tar.gz -C ./bin
-          mv ./bin/uv-x86_64-unknown-linux-gnu/uv ./assets/uv
-          rm -rf ./bin/uv-x86_64-unknown-linux-gnu
-          ls -alF ./bin
-          ls -alF ./assets
+          tar -xzf uv.tar.gz -C ./temp
+          mv ./temp/uv-x86_64-unknown-linux-gnu/uv ./assets/bin/uv
+          rm -rf ./temp/uv-x86_64-unknown-linux-gnu
 
       - name: setup nodejs
         uses: actions/setup-node@v4
@@ -55,13 +54,12 @@ jobs:
 
       - name: Download uv
         run: |
-          mkdir bin
+          mkdir temp
+          mkdir -p ./assets/bin
           curl -L https://github.com/astral-sh/uv/releases/download/${{ env.UV_VERSION }}/uv-aarch64-apple-darwin.tar.gz -o uv.tar.gz
-          tar -xzf uv.tar.gz -C ./bin
-          mv ./bin/uv-aarch64-apple-darwin/uv ./assets/uv
-          rm -rf ./bin/uv-aarch64-apple-darwin
-          ls -alF ./bin
-          ls -alF ./assets
+          tar -xzf uv.tar.gz -C ./temp
+          mv ./temp/uv-aarch64-apple-darwin/uv ./assets/bin/uv
+          rm -rf ./temp/uv-aarch64-apple-darwin
 
       - name: setup nodejs
         uses: actions/setup-node@v4
@@ -87,10 +85,11 @@ jobs:
 
       - name: Download uv
         run: |
-          mkdir bin
+          mkdir temp
+          mkdir -p ./assets/bin
           curl -L https://github.com/astral-sh/uv/releases/download/${{ env.UV_VERSION }}/uv-x86_64-pc-windows-msvc.zip -o uv.zip
-          unzip uv.zip -d bin/
-          mv bin/uv.exe assets/uv.exe
+          unzip uv.zip -d temp/
+          mv temp/uv.exe assets/bin/uv.exe
 
       - name: setup nodejs
         uses: actions/setup-node@v4

--- a/package.json
+++ b/package.json
@@ -117,11 +117,8 @@
     ],
     "extraResources": [
       {
-        "from": "assets/",
-        "to": ".",
-        "filter": [
-          "uv*"
-        ]
+        "from": "assets/bin",
+        "to": "./bin"
       }
     ],
     "linux": {

--- a/src/lib/pty.test.ts
+++ b/src/lib/pty.test.ts
@@ -15,6 +15,7 @@ describe('PtyManager', () => {
   let mockPtyProcess: any;
 
   beforeEach(() => {
+    (process as any).resourcesPath = '/mock/path';
     ptyManager = new PtyManager();
     mockPtyProcess = {
       onData: vi.fn(),

--- a/src/lib/pty.test.ts
+++ b/src/lib/pty.test.ts
@@ -3,7 +3,6 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
 import * as pty from 'node-pty';
-import { assert } from 'tsafe';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { PtyManager } from '@/lib/pty';
@@ -31,55 +30,61 @@ describe('PtyManager', () => {
     vi.clearAllMocks();
   });
 
-  it('should create a new pty process', () => {
+  it('should create a new pty entry', () => {
     const onData = vi.fn();
     const onExit = vi.fn();
-    const id = ptyManager.create({ onData, onExit });
+    const entry = ptyManager.create({ onData, onExit });
 
-    expect(id).toBeDefined();
+    expect(entry).toBeDefined();
     expect(pty.spawn).toHaveBeenCalled();
     expect(mockPtyProcess.onData).toHaveBeenCalled();
     expect(mockPtyProcess.onExit).toHaveBeenCalled();
   });
 
+  it('should store the created pty entry', () => {
+    const onData = vi.fn();
+    const onExit = vi.fn();
+    const entry = ptyManager.create({ onData, onExit });
+
+    expect(ptyManager.ptys.get(entry.id)).toBe(entry);
+  });
+
   it('should write data to the pty process', () => {
     const onData = vi.fn();
     const onExit = vi.fn();
-    const id = ptyManager.create({ onData, onExit });
+    const entry = ptyManager.create({ onData, onExit });
 
-    ptyManager.write(id, 'test data');
+    ptyManager.write(entry.id, 'test data');
     expect(mockPtyProcess.write).toHaveBeenCalledWith('test data');
   });
 
   it('should resize the pty process', () => {
     const onData = vi.fn();
     const onExit = vi.fn();
-    const id = ptyManager.create({ onData, onExit });
+    const entry = ptyManager.create({ onData, onExit });
 
-    ptyManager.resize(id, 1337, 90001);
+    ptyManager.resize(entry.id, 1337, 90001);
     expect(mockPtyProcess.resize).toHaveBeenCalledWith(1337, 90001);
   });
 
   it('should replay the buffer', () => {
     const onData = vi.fn();
     const onExit = vi.fn();
-    const id = ptyManager.create({ onData, onExit });
-    const entry = ptyManager.ptys.get(id);
-    assert(entry);
+    const entry = ptyManager.create({ onData, onExit });
     const data = 'test data';
     entry.historyBuffer.push(data);
-    const replayData = ptyManager.replay(id);
+    const replayData = ptyManager.replay(entry.id);
     expect(replayData).toBe(data);
   });
 
   it('should dispose of the pty process', () => {
     const onData = vi.fn();
     const onExit = vi.fn();
-    const id = ptyManager.create({ onData, onExit });
+    const entry = ptyManager.create({ onData, onExit });
 
-    ptyManager.dispose(id);
+    ptyManager.dispose(entry.id);
     expect(mockPtyProcess.kill).toHaveBeenCalled();
-    expect(ptyManager.ptys.has(id)).toBe(false);
+    expect(ptyManager.ptys.has(entry.id)).toBe(false);
   });
 
   it('should teardown all pty processes', () => {
@@ -96,12 +101,12 @@ describe('PtyManager', () => {
   it('should list all pty ids', () => {
     const onData = vi.fn();
     const onExit = vi.fn();
-    const id1 = ptyManager.create({ onData, onExit });
-    const id2 = ptyManager.create({ onData, onExit });
+    const entry1 = ptyManager.create({ onData, onExit });
+    const entry2 = ptyManager.create({ onData, onExit });
 
     const ids = ptyManager.list();
-    expect(ids).toContain(id1);
-    expect(ids).toContain(id2);
+    expect(ids).toContain(entry1.id);
+    expect(ids).toContain(entry2.id);
     expect(ids).toHaveLength(2);
   });
 });

--- a/src/lib/pty.ts
+++ b/src/lib/pty.ts
@@ -52,6 +52,11 @@ export class PtyManager {
       cwd: options?.cwd ?? process.env.HOME,
       env,
     });
+
+    if (shell === 'Powershell.exe') {
+      ptyProcess.write(`$env:PATH="${env.PATH}"\r`);
+    }
+
     const ansiSequenceBuffer = new AnsiSequenceBuffer();
     const historyBuffer = new SlidingBuffer<string>(this.options.maxHistorySize);
 

--- a/src/main/pty-manager.ts
+++ b/src/main/pty-manager.ts
@@ -29,16 +29,17 @@ export const createPtyManager = (arg: {
       cwd: getHomeDirectory(),
     };
 
+    const entry = ptyManager.create({ onData, onExit, options });
+
+
     if (cwd) {
       const installDetails = await getInstallationDetails(cwd);
       if (installDetails.isInstalled) {
-        options.cmd = [getActivateVenvCommand(installDetails.path)];
-        options.cwd = installDetails.path;
+        entry.process.write(getActivateVenvCommand(installDetails.path));
       }
     }
 
-    const id = ptyManager.create({ onData, onExit, options });
-    return id;
+    return entry.id;
   });
   ipc.handle('terminal:dispose', (_, id) => ptyManager.dispose(id));
   ipc.handle('terminal:resize', (_, id, cols, rows) => ptyManager.resize(id, cols, rows));

--- a/src/main/pty-manager.ts
+++ b/src/main/pty-manager.ts
@@ -32,7 +32,7 @@ export const createPtyManager = (arg: {
 
     // Add the bundled bin dir to the PATH env var
     if (process.platform === 'win32') {
-      entry.process.write(`$env:Path='${getBundledBinPath()}';$env:Path\r`);
+      entry.process.write(`$env:Path='${getBundledBinPath()};'+$env:Path\r`);
     } else {
       // macOS, Linux
       entry.process.write(`export PATH="${getBundledBinPath()}:$PATH"\r`);

--- a/src/main/util.ts
+++ b/src/main/util.ts
@@ -260,7 +260,7 @@ export const killProcess = (childProcess: ChildProcess): void => {
  * are set, they will be used. Otherwise, Windows will default to Powershell and Linux/macOS will default to sh.
  * @returns The shell to use for running commands
  */
-export const getShell = (): string => {
+export const getShell = () => {
   if (process.platform === 'win32') {
     return 'Powershell.exe';
   } else if (process.platform === 'darwin') {

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -241,10 +241,6 @@ export type PtyOptions = {
    */
   cwd?: string;
   /**
-   * An array of command to execute in the terminal on startup.
-   */
-  cmd?: string[];
-  /**
    * The initial size of the terminal.
    */
   size?: { cols: number; rows: number };


### PR DESCRIPTION
- Add a `bin` dir to `process.resourcesPath` and put `uv` there instead of directly in `process.resourcesPath`
- Adjust some variable names in util.ts to prevent clobbering the `path` module
- Add util to get the new `bin` path, update `getUVExecutablePath` to use this
- Prepend the new `bin` path when creating PTYs so that the `uv` executable is available
- Rearrange some PTY logic to shift responsibility of executing anything outside the `PtyManager` class