### PR TITLE
ci: split jobs into build/check/test

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,4 @@
-name: Build Binaries
+name: Build Unsigned Binaries
 
 on:
   push:

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -1,9 +1,9 @@
-name: Run Tests
+name: Run Code Quality Checks
 
 on: [push, workflow_dispatch]
 
 jobs:
-  test:
+  check:
     runs-on: ubuntu-latest
 
     steps:
@@ -18,5 +18,5 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Run tests
-        run: npm run test:no-watch
+      - name: Run code quality checks
+        run: npm run lint


### PR DESCRIPTION
Also remove the dependency on xvfb as we don't need a running X server at the moment.