### PR TITLE
fix: link to loopback url

### DIFF
--- a/src/renderer/features/LaunchFlow/LaunchFlowLogViewer.tsx
+++ b/src/renderer/features/LaunchFlow/LaunchFlowLogViewer.tsx
@@ -13,7 +13,7 @@ import type { InvokeProcessStatus } from '@/shared/types';
 
 const getMessage = (status: InvokeProcessStatus) => {
   if (status.type === 'running') {
-    return `Running at ${status.data.url}`;
+    return `Running at ${status.data.loopbackUrl}`;
   }
   return startCase(status.type);
 };

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -212,7 +212,26 @@ export type InstallProcessStatus = Status<
  */
 export type InvokeProcessStatus =
   | Status<'uninitialized' | 'starting' | 'exiting' | 'exited'>
-  | OkStatus<'running', { url: string }>;
+  | OkStatus<
+      'running',
+      {
+        /**
+         * The URL at which the server is running. The user can access the server from the host machine using this URL.
+         */
+        loopbackUrl: string;
+        /**
+         * The URL at which the server is running on the LAN. The user can access the server from other devices on the
+         * same network using this URL. This field is only present if the server is accessible on the LAN.
+         */
+        lanUrl?: string;
+        /**
+         * The URL at which the server is running as reported by uvicorn. It may have 0.0.0.0 as the host.
+         *
+         * You probably want to use `loopbackUrl` instead.
+         */
+        url: string;
+      }
+    >;
 
 /**
  * A logging level.


### PR DESCRIPTION
From @SkunkWorxDark:
> Minor niggle with the new installer.  When it opens the browser on a machine that has server ip as 0.0.0.0 it uses the actual ip adress of the machine.  This causes chrome to mark it as Not Secure and therefore disables the right click copy image functionality.  Using 127.0.0.1:9090 or localhost:9090 would prevent this.

Ref: https://discord.com/channels/1020123559063990373/1149506274971631688/1320707441180147783