### PR TITLE
feat: repair install mode

### DIFF
--- a/src/renderer/app/App.tsx
+++ b/src/renderer/app/App.tsx
@@ -1,4 +1,4 @@
-import { Box, Divider, Flex } from '@invoke-ai/ui-library';
+import { Box, Divider, Flex, useGlobalModifiersInit } from '@invoke-ai/ui-library';
 import { ErrorBoundary } from 'react-error-boundary';
 
 import { ErrorBoundaryFallback } from '@/renderer/app/ErrorBoundaryFallback';
@@ -13,6 +13,8 @@ import { ConsoleOpenButton } from '@/renderer/features/Console/ConsoleOpenButton
 import { SettingsModal } from '@/renderer/features/SettingsModal/SettingsModal';
 
 export const App = () => {
+  useGlobalModifiersInit();
+
   return (
     <ThemeProvider>
       <SystemInfoProvider>

--- a/src/renderer/features/InstallFlow/InstallFlowStepReview.tsx
+++ b/src/renderer/features/InstallFlow/InstallFlowStepReview.tsx
@@ -1,4 +1,4 @@
-import { Button, Divider, Heading, ListItem, Text, UnorderedList } from '@invoke-ai/ui-library';
+import { Button, Divider, Heading, ListItem, Text, UnorderedList, useShiftModifier } from '@invoke-ai/ui-library';
 import { useStore } from '@nanostores/react';
 import { memo } from 'react';
 import { assert } from 'tsafe';
@@ -20,6 +20,8 @@ const GPU_LABEL_MAP: Record<GpuType, string> = {
 export const InstallFlowStepReview = memo(() => {
   const { dirDetails, gpuType, release } = useStore(installFlowApi.$choices);
   const installType = useStore(installFlowApi.$installType);
+
+  const shift = useShiftModifier();
 
   assert(dirDetails !== null);
   assert(gpuType !== null);
@@ -63,9 +65,16 @@ export const InstallFlowStepReview = memo(() => {
           Back
         </Button>
         <Divider orientation="vertical" />
-        <Button onClick={installFlowApi.startInstall} colorScheme="invokeYellow">
-          Install
-        </Button>
+        {shift && (
+          <Button onClick={installFlowApi.startInstallWithRepair} colorScheme="invokeRed">
+            Repair
+          </Button>
+        )}
+        {!shift && (
+          <Button onClick={installFlowApi.startInstallWithoutRepair} colorScheme="invokeYellow">
+            Install
+          </Button>
+        )}
       </BodyFooter>
     </BodyContainer>
   );

--- a/src/renderer/features/InstallFlow/state.ts
+++ b/src/renderer/features/InstallFlow/state.ts
@@ -90,14 +90,20 @@ export const installFlowApi = {
     $activeStep.set(0);
     $isStarted.set(false);
   },
-  startInstall: () => {
+  startInstall: (repair?: boolean) => {
     const { dirDetails, gpuType, release } = $choices.get();
     if (!dirDetails || !dirDetails.canInstall || !release || !gpuType) {
       return;
     }
     $installProcessLogs.set([]);
-    emitter.invoke('install-process:start-install', dirDetails.path, gpuType, release.version);
+    emitter.invoke('install-process:start-install', dirDetails.path, gpuType, release.version, repair);
     installFlowApi.nextStep();
+  },
+  startInstallWithoutRepair: () => {
+    installFlowApi.startInstall(false);
+  },
+  startInstallWithRepair: () => {
+    installFlowApi.startInstall(true);
   },
   cancelInstall: async () => {
     await emitter.invoke('install-process:cancel-install');

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -297,7 +297,7 @@ type InstallProcessIpcEvents = Namespaced<
   'install-process',
   {
     'get-status': () => WithTimestamp<InstallProcessStatus>;
-    'start-install': (location: string, gpuType: GpuType, version: string) => void;
+    'start-install': (location: string, gpuType: GpuType, version: string, repair?: boolean) => void;
     'cancel-install': () => void;
   }
 >;


### PR DESCRIPTION
Adds a repair mode to the installer. This does two things:
- Forcibly reinstall the `uv`-managed python
- Delete the existing virtual environment if it exists

I was running into issues with an apparently borked python install, which I could only fix by forcibly reinstalling the `uv`-managed python. This recovery feature allows users to do this if needed. Hold on the "Review" step to change the install button to a repair button, which triggers the extra repair steps during install.

This change also moves the python install location to the launcher's bundled binary dir (where the `uv` executable is stored). This ensures our python install is totally separate from the rest of the system and any other `uv` managed python installs. It allows us to do whatever we want with it, including delete it or reinstall it freely without impacting the system.