### PR TITLE
feat: start dev console in install location if possible

### DIFF
--- a/src/main/pty-manager.ts
+++ b/src/main/pty-manager.ts
@@ -40,9 +40,15 @@ export const createPtyManager = (arg: {
 
     if (cwd) {
       const installDetails = await getInstallationDetails(cwd);
+      // If the cwd is a valid installation dir, we should activate the venv
       if (installDetails.isInstalled) {
         const activateVenvCmd = getActivateVenvCommand(installDetails.path);
         entry.process.write(`${activateVenvCmd}\r`);
+      }
+      // If the cwd is a directory, we should cd into it, even if it is not a valid installation dir - the user may
+      // want to run commands there to fix something.
+      if (installDetails.isDirectory) {
+        entry.process.write(`cd ${cwd}\r`);
       }
     }
 


### PR DESCRIPTION
Previously it started in the user's home directory.

Now it `cd`s into the install location if it is a directory (regardless of whether or not the install is valid - the user may want to try and fix something in there).

Ref: @SkunkWorxDark, https://discord.com/channels/1020123559063990373/1149506274971631688/1326287340599251037