### PR TITLE
fix: use uv path for managed python installs

### DIFF
--- a/src/main/install-manager.ts
+++ b/src/main/install-manager.ts
@@ -11,7 +11,7 @@ import { assert } from 'tsafe';
 import { withResult, withResultAsync } from '@/lib/result';
 import { SimpleLogger } from '@/lib/simple-logger';
 import { FIRST_RUN_MARKER_FILENAME } from '@/main/constants';
-import { getBundledBinPath, getTorchPlatform, getUVExecutablePath, isDirectory, isFile } from '@/main/util';
+import { getTorchPlatform, getUVExecutablePath, isDirectory, isFile } from '@/main/util';
 import { getPins } from '@/shared/pins';
 import type {
   GpuType,
@@ -160,12 +160,7 @@ export class InstallManager {
 
     const runProcessOptions = {
       signal: abortController.signal,
-      env: {
-        ...process.env,
-        // This is used by `uv` to determine where to install python. We'll install python here so there's no chance
-        // of conflicts with any other `uv`-managed python installations.
-        UV_PYTHON_INSTALL_DIR: getBundledBinPath(),
-      },
+      env: process.env,
     };
 
     // First step - install python

--- a/src/main/util.ts
+++ b/src/main/util.ts
@@ -24,7 +24,8 @@ export const getOperatingSystem = (): OperatingSystem => {
 };
 
 /**
- * Get the path to the bundled bin directory
+ * Get the path to the bundled bin directory. This directory holds executables that are bundled with the app. These
+ * resources are extracted at runtime and deleted when the app is closed - do not store anything important here.
  */
 export const getBundledBinPath = (): string => {
   if (isDevelopment()) {


### PR DESCRIPTION
I had mistakenly believed that `process.resourcesPath` was a persistent directory and downloaded our portable python to this directory. This is actually an ephemeral temp directory.

As a result, the python installed when installing Invoke via launcher was deleted when the launcher closed.

Due to a fluke of dev environment setup, this problem wasn't caught.

This commit walks back the attempt to store our own portable python separately from uv's default install locations. It should resolve issues where the launcher fails to find or remember the user's installation.