### PR TITLE
feat: more efficient install logic

### DIFF
--- a/src/main/install-manager.ts
+++ b/src/main/install-manager.ts
@@ -277,7 +277,7 @@ export class InstallManager {
       this.log.info('Virtual environment already exists, skipping...\r\n');
     }
 
-    // Third step - install the invokeai package
+    // Install the invokeai package
     const installInvokeArgs = [
       // Use `uv`s pip interface to install the invokeai package
       'pip',
@@ -324,7 +324,9 @@ export class InstallManager {
       return;
     }
 
-    // Create a marker file to indicate that the next run is the first run since installation
+    // Create a marker file to indicate that the next run is the first run since installation.
+    // The first run takes a while, presumably due to python bytecode compilation. When we run the app, we check
+    // for this marker file and log a message if it exists. Once started up, we delete the marker file.
     const firstRunMarkerPath = join(location, FIRST_RUN_MARKER_FILENAME);
     fs.writeFile(firstRunMarkerPath, '').catch(() => {
       this.log.warn('Failed to create first run marker file\r\n');

--- a/src/renderer/features/InstallFlow/InstallFlowStepReview.tsx
+++ b/src/renderer/features/InstallFlow/InstallFlowStepReview.tsx
@@ -1,4 +1,13 @@
-import { Button, Divider, Heading, ListItem, Text, UnorderedList, useShiftModifier } from '@invoke-ai/ui-library';
+import {
+  Button,
+  Divider,
+  Heading,
+  ListItem,
+  Text,
+  Tooltip,
+  UnorderedList,
+  useShiftModifier,
+} from '@invoke-ai/ui-library';
 import { useStore } from '@nanostores/react';
 import { memo } from 'react';
 import { assert } from 'tsafe';
@@ -59,6 +68,14 @@ export const InstallFlowStepReview = memo(() => {
             </Text>
           </ListItem>
         </UnorderedList>
+        {/* {shift && (
+          <Alert status="info" w="auto" mt={8}>
+            <AlertIcon />
+            <AlertDescription fontSize="sm">
+              Repair mode forcibly reinstalls python and recreates the virtual environment.
+            </AlertDescription>
+          </Alert>
+        )} */}
       </BodyContent>
       <BodyFooter>
         <Button onClick={installFlowApi.prevStep} variant="link">
@@ -66,12 +83,14 @@ export const InstallFlowStepReview = memo(() => {
         </Button>
         <Divider orientation="vertical" />
         {shift && (
-          <Button onClick={installFlowApi.startInstallWithRepair} colorScheme="invokeRed">
-            Repair
-          </Button>
+          <Tooltip isOpen label="Repair mode forcibly reinstalls python and recreates the virtual environment.">
+            <Button w={24} onClick={installFlowApi.startInstallWithRepair} colorScheme="invokeRed">
+              Repair
+            </Button>
+          </Tooltip>
         )}
         {!shift && (
-          <Button onClick={installFlowApi.startInstallWithoutRepair} colorScheme="invokeYellow">
+          <Button w={24} onClick={installFlowApi.startInstallWithoutRepair} colorScheme="invokeYellow">
             Install
           </Button>
         )}


### PR DESCRIPTION
- Only reinstall python in repair mode.
- Only recreate venv in repair mode. Closes #41.
- Add tooltip to `Repair` button that describes what it will do.