### PR TITLE
feat: support manual version entry

### DIFF
--- a/src/renderer/features/InstallFlow/InstallFlowInstallTypeDescription.tsx
+++ b/src/renderer/features/InstallFlow/InstallFlowInstallTypeDescription.tsx
@@ -1,4 +1,5 @@
 import { Text } from '@invoke-ai/ui-library';
+import { valid } from '@renovatebot/pep440';
 import { memo } from 'react';
 
 import { Strong } from '@/renderer/common/Strong';
@@ -39,6 +40,29 @@ export const InstallFlowInstallTypeDescription = memo(({ installType }: Props) =
       </Text>
     );
   }
+  if (installType.type === 'manual') {
+    const isValid = valid(installType.newVersion) !== null;
+
+    if (!isValid) {
+      return <></>;
+    }
+
+    return (
+      <Text fontSize="md">
+        We&apos;ll install the manually specified version <Strong>{installType.newVersion}</Strong> on top of your
+        existing <Strong>Invoke {installType.installedVersion}</Strong> install.
+      </Text>
+    );
+  }
 });
 
 InstallFlowInstallTypeDescription.displayName = 'InstallFlowInstallTypeDescription';
+
+export const ManualVersionWarning = memo(() => {
+  return (
+    <Text fontSize="md" color="warning.300" fontWeight="semibold">
+      Manual version installation can break things. Make sure to back up your data first.
+    </Text>
+  );
+});
+ManualVersionWarning.displayName = 'ManualVersionWarning';

--- a/src/renderer/features/InstallFlow/InstallFlowStepReview.tsx
+++ b/src/renderer/features/InstallFlow/InstallFlowStepReview.tsx
@@ -19,7 +19,10 @@ import { assert } from 'tsafe';
 
 import { BodyContainer, BodyContent, BodyFooter, BodyHeader } from '@/renderer/common/layout';
 import { Strong } from '@/renderer/common/Strong';
-import { InstallFlowInstallTypeDescription } from '@/renderer/features/InstallFlow/InstallFlowInstallTypeDescription';
+import {
+  InstallFlowInstallTypeDescription,
+  ManualVersionWarning,
+} from '@/renderer/features/InstallFlow/InstallFlowInstallTypeDescription';
 import { InstallFlowStepper } from '@/renderer/features/InstallFlow/InstallFlowStepper';
 import { installFlowApi } from '@/renderer/features/InstallFlow/state';
 import type { GpuType } from '@/shared/types';
@@ -55,18 +58,23 @@ export const InstallFlowStepReview = memo(() => {
           <ListItem>
             <InstallFlowInstallTypeDescription installType={installType} />
           </ListItem>
-          {release.isPrerelease && (
+          {release.type === 'gh' && release.isPrerelease && (
             <ListItem>
               <Text fontSize="md">
                 This is a <Strong>prerelease</Strong> of Invoke. Thanks for helping us test it!
               </Text>
             </ListItem>
           )}
-          {!release.isPrerelease && (
+          {release.type === 'gh' && !release.isPrerelease && (
             <ListItem>
               <Text fontSize="md">
                 This is a <Strong>stable</Strong> release of Invoke.
               </Text>
+            </ListItem>
+          )}
+          {release.type === 'manual' && (
+            <ListItem>
+              <ManualVersionWarning />
             </ListItem>
           )}
           <ListItem>

--- a/src/renderer/features/InstallFlow/InstallFlowStepVersion.tsx
+++ b/src/renderer/features/InstallFlow/InstallFlowStepVersion.tsx
@@ -1,5 +1,6 @@
 import { Button, Divider } from '@invoke-ai/ui-library';
 import { useStore } from '@nanostores/react';
+import { valid } from '@renovatebot/pep440';
 import { memo } from 'react';
 
 import { BodyContainer, BodyContent, BodyFooter, BodyHeader } from '@/renderer/common/layout';
@@ -23,7 +24,11 @@ export const InstallFlowStepVersion = memo(() => {
           Back
         </Button>
         <Divider orientation="vertical" />
-        <Button onClick={installFlowApi.nextStep} isDisabled={!release} colorScheme="invokeYellow">
+        <Button
+          onClick={installFlowApi.nextStep}
+          isDisabled={!release || valid(release.version) === null}
+          colorScheme="invokeYellow"
+        >
           Next
         </Button>
       </BodyFooter>

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -162,7 +162,7 @@ export type InstallType =
       newVersion: string;
     }
   | {
-      type: 'reinstall' | 'upgrade' | 'downgrade';
+      type: 'reinstall' | 'upgrade' | 'downgrade' | 'manual';
       newVersion: string;
       installedVersion: string;
     };


### PR DESCRIPTION
Another option is added to the version picker for manual version entry. When selected, a free-text entry field is presented.

When manual version entry is used, the user is warned that manual version installation can break things and to back up their data to be safe.

The version is checked against PEP440 to ensure it is a valid version string, but we do not query PyPI to confirm it is a valid version for Invoke. If it is not a valid version, the install will simply fail.

A future enhancement could add validation against PyPI.

Demo of the feature:

<video src="https://github.com/user-attachments/assets/896f3765-75aa-4120-9502-64e18cc3cb66"></video>