### PR TITLE
fix: log memory leak

### DIFF
--- a/src/renderer/constants.ts
+++ b/src/renderer/constants.ts
@@ -1,1 +1,4 @@
-export const POLL_INTERVAL = 1_000;
+/**
+ * The interval in milliseconds to poll the status of a process. Used for the main, install and invoke processes.
+ */
+export const STATUS_POLL_INTERVAL_MS = 1_000;

--- a/src/renderer/constants.ts
+++ b/src/renderer/constants.ts
@@ -2,3 +2,11 @@
  * The interval in milliseconds to poll the status of a process. Used for the main, install and invoke processes.
  */
 export const STATUS_POLL_INTERVAL_MS = 1_000;
+/**
+ * The maximum number of logs to keep in the install process log buffer.
+ */
+export const INVOKE_PROCESS_LOG_LIMIT = 1_000;
+/**
+ * The maximum number of logs to keep in the invoke process log buffer.
+ */
+export const INSTALL_PROCESS_LOG_LIMIT = 1_000;

--- a/src/renderer/features/InstallFlow/state.ts
+++ b/src/renderer/features/InstallFlow/state.ts
@@ -6,7 +6,7 @@ import { assert } from 'tsafe';
 
 import { LineBuffer } from '@/lib/line-buffer';
 import { withResultAsync } from '@/lib/result';
-import { STATUS_POLL_INTERVAL_MS } from '@/renderer/constants';
+import { INSTALL_PROCESS_LOG_LIMIT, STATUS_POLL_INTERVAL_MS } from '@/renderer/constants';
 import { $latestGHReleases } from '@/renderer/services/gh';
 import { emitter, ipc } from '@/renderer/services/ipc';
 import {
@@ -185,6 +185,9 @@ $installProcessStatus.subscribe((status, oldStatus) => {
 });
 
 export const $installProcessLogs = atom<WithTimestamp<LogEntry>[]>([]);
+const appendToInstallProcessLogs = (entry: WithTimestamp<LogEntry>) => {
+  $installProcessLogs.set([...$installProcessLogs.get(), entry].slice(-INSTALL_PROCESS_LOG_LIMIT));
+};
 
 export const getIsActiveInstallProcessStatus = (status: InstallProcessStatus) => {
   switch (status.type) {
@@ -204,7 +207,7 @@ const listen = () => {
   ipc.on('install-process:log', (_, data) => {
     const buffered = buffer.append(data.message);
     for (const message of buffered) {
-      $installProcessLogs.set([...$installProcessLogs.get(), { ...data, message }]);
+      appendToInstallProcessLogs({ ...data, message });
     }
   });
 

--- a/src/renderer/features/InstallFlow/state.ts
+++ b/src/renderer/features/InstallFlow/state.ts
@@ -215,7 +215,11 @@ const listen = () => {
     $installProcessStatus.set(status);
     if (status.type === 'canceled' || status.type === 'completed' || status.type === 'error') {
       // Flush the buffer when the process exits in case there were any remaining logs
-      buffer.flush();
+      const finalMessage = buffer.flush();
+      const lastLog = $installProcessLogs.get().slice(-1)[0];
+      if (lastLog && finalMessage) {
+        appendToInstallProcessLogs({ ...lastLog, message: finalMessage });
+      }
 
       // If the install was canceled or errored, we need to force a sync of the install dir details in case something
       // broke

--- a/src/renderer/features/InstallFlow/state.ts
+++ b/src/renderer/features/InstallFlow/state.ts
@@ -6,7 +6,7 @@ import { assert } from 'tsafe';
 
 import { LineBuffer } from '@/lib/line-buffer';
 import { withResultAsync } from '@/lib/result';
-import { POLL_INTERVAL } from '@/renderer/constants';
+import { STATUS_POLL_INTERVAL_MS } from '@/renderer/constants';
 import { $latestGHReleases } from '@/renderer/services/gh';
 import { emitter, ipc } from '@/renderer/services/ipc';
 import {
@@ -229,7 +229,7 @@ const listen = () => {
     $installProcessStatus.set(newStatus);
   };
 
-  setInterval(poll, POLL_INTERVAL);
+  setInterval(poll, STATUS_POLL_INTERVAL_MS);
 };
 
 listen();

--- a/src/renderer/features/LaunchFlow/state.ts
+++ b/src/renderer/features/LaunchFlow/state.ts
@@ -2,7 +2,7 @@ import { isEqual } from 'lodash-es';
 import { atom, computed } from 'nanostores';
 
 import { LineBuffer } from '@/lib/line-buffer';
-import { POLL_INTERVAL } from '@/renderer/constants';
+import { STATUS_POLL_INTERVAL_MS } from '@/renderer/constants';
 import { emitter, ipc } from '@/renderer/services/ipc';
 import { syncInstallDirDetails } from '@/renderer/services/store';
 import type { InvokeProcessStatus, LogEntry, WithTimestamp } from '@/shared/types';
@@ -63,7 +63,7 @@ const listen = () => {
     $invokeProcessStatus.set(newStatus);
   };
 
-  setInterval(poll, POLL_INTERVAL);
+  setInterval(poll, STATUS_POLL_INTERVAL_MS);
 };
 
 listen();

--- a/src/renderer/features/LaunchFlow/state.ts
+++ b/src/renderer/features/LaunchFlow/state.ts
@@ -50,7 +50,11 @@ const listen = () => {
     $invokeProcessStatus.set(status);
     if (status.type === 'exited' || status.type === 'error') {
       // Flush the buffer when the process exits in case there were any remaining logs
-      buffer.flush();
+      const finalMessage = buffer.flush();
+      const lastLog = $invokeProcessLogs.get().slice(-1)[0];
+      if (lastLog && finalMessage) {
+        appendToInvokeProcessLogs({ ...lastLog, message: finalMessage });
+      }
 
       // If the invoke process errored, we need to force a sync of the install dir details in case something broke
       syncInstallDirDetails();

--- a/src/renderer/services/status.ts
+++ b/src/renderer/services/status.ts
@@ -1,7 +1,7 @@
 import { isEqual } from 'lodash-es';
 import { atom } from 'nanostores';
 
-import { POLL_INTERVAL } from '@/renderer/constants';
+import { STATUS_POLL_INTERVAL_MS } from '@/renderer/constants';
 import { emitter, ipc } from '@/renderer/services/ipc';
 import type { MainProcessStatus, WithTimestamp } from '@/shared/types';
 
@@ -30,7 +30,7 @@ const listen = () => {
     $mainProcessStatus.set(newStatus);
   };
 
-  setInterval(poll, POLL_INTERVAL);
+  setInterval(poll, STATUS_POLL_INTERVAL_MS);
 };
 
 listen();


### PR DESCRIPTION
Previously the logs for the invoke and install processes could be any size. Limited now to 1000 entries.

Also fixed an issue where the last log message might not be rendered in the UI.