### PR TITLE
fix: manually specify venv when installing invokeai pkg

### DIFF
--- a/src/main/install-manager.ts
+++ b/src/main/install-manager.ts
@@ -306,6 +306,10 @@ export class InstallManager {
       installInvokeArgs.push(`--index=${torchIndexUrl}`);
     }
 
+    // Manually set the VIRTUAL_ENV environment variable to the venv path to ensure `uv` uses it correctly.
+    // Unfortunately there is no way to specify this in the `uv` CLI.
+    runProcessOptions.env.VIRTUAL_ENV = venvPath;
+
     this.log.info('Installing invokeai package...\r\n');
     this.log.info(`> ${uvPath} ${installInvokeArgs.join(' ')}\r\n`);
 


### PR DESCRIPTION
This fixes an issue @ShaneDK had, where `uv` failed to find the virtual environment for the Invoke install.

I had made a custom builder for them, but not yet merged this fix into `main`.