### PR TITLE
feat: support fetching python/indices from invoke repo 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "invoke-community-edition",
-  "version": "1.3.2",
+  "version": "1.4.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "invoke-community-edition",
-      "version": "1.3.2",
+      "version": "1.4.1",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -38,7 +38,8 @@
         "serialize-error": "^11.0.3",
         "strip-ansi": "^7.1.0",
         "tsafe": "^1.8.5",
-        "use-stick-to-bottom": "^1.0.42"
+        "use-stick-to-bottom": "^1.0.42",
+        "zod": "^3.24.2"
       },
       "devDependencies": {
         "@electron-forge/cli": "^7.6.0",
@@ -17827,10 +17828,10 @@
       }
     },
     "node_modules/zod": {
-      "version": "3.24.0",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.24.0.tgz",
-      "integrity": "sha512-Hz+wiY8yD0VLA2k/+nsg2Abez674dDGTai33SwNvMPuf9uIrBC9eFgIMQxBBbHFxVXi8W+5nX9DcAh9YNSQm/w==",
-      "dev": true,
+      "version": "3.24.2",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.24.2.tgz",
+      "integrity": "sha512-lY7CDW43ECgW9u1TcT3IoXHflywfVqDYze4waEz812jR/bZ8FHDsl7pFQoSZTz5N+2NqRXs8GBwnAwo3ZNxqhQ==",
+      "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package.json
+++ b/package.json
@@ -114,7 +114,8 @@
     "serialize-error": "^11.0.3",
     "strip-ansi": "^7.1.0",
     "tsafe": "^1.8.5",
-    "use-stick-to-bottom": "^1.0.42"
+    "use-stick-to-bottom": "^1.0.42",
+    "zod": "^3.24.2"
   },
   "build": {
     "appId": "com.invoke.invoke-community-edition",

--- a/src/main/install-manager.ts
+++ b/src/main/install-manager.ts
@@ -8,7 +8,7 @@ import path, { join } from 'path';
 import { serializeError } from 'serialize-error';
 import { assert } from 'tsafe';
 
-import { withResult, withResultAsync } from '@/lib/result';
+import { withResultAsync } from '@/lib/result';
 import { SimpleLogger } from '@/lib/simple-logger';
 import { FIRST_RUN_MARKER_FILENAME } from '@/main/constants';
 import { getTorchPlatform, getUVExecutablePath, isDirectory, isFile } from '@/main/util';
@@ -112,7 +112,7 @@ export class InstallManager {
     }
 
     // Get the Python version and torch index URL for the target version
-    const pinsResult = await withResult(() => getPins(version));
+    const pinsResult = await withResultAsync(() => getPins(version));
 
     if (pinsResult.isErr()) {
       this.log.error(`Failed to get pins for version ${version}: ${pinsResult.error.message}\r\n`);


### PR DESCRIPTION
The repo now has a `pins.json` file, which records the requisite python version and PyPI torch index URLs for that specific version of Invoke.

The launcher now fetches this data and uses it during installation. This allows the repo to take responsibility for python and index URLs. We do not need to update the launcher to handle changes to python/torch versions.