### PR TITLE
feat: suite of memory usage improvements

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,7 @@
         "electron-squirrel-startup": "^1.0.1",
         "electron-store": "^10.1.0",
         "es-toolkit": "^1.39.8",
+        "filesize": "^11.0.2",
         "ip": "^2.0.1",
         "linkify-react": "^4.3.2",
         "linkifyjs": "^4.3.2",
@@ -9369,6 +9370,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/filesize": {
+      "version": "11.0.2",
+      "resolved": "https://registry.npmjs.org/filesize/-/filesize-11.0.2.tgz",
+      "integrity": "sha512-s/iAeeWLk5BschUIpmdrF8RA8lhFZ/xDZgKw1Tan72oGws1/dFGB06nYEiyyssWUfjKNQTNRlrwMVjO9/hvXDw==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">= 10.4.0"
       }
     },
     "node_modules/fill-range": {

--- a/package.json
+++ b/package.json
@@ -101,6 +101,7 @@
     "electron-squirrel-startup": "^1.0.1",
     "electron-store": "^10.1.0",
     "es-toolkit": "^1.39.8",
+    "filesize": "^11.0.2",
     "ip": "^2.0.1",
     "linkify-react": "^4.3.2",
     "linkifyjs": "^4.3.2",

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -16,6 +16,21 @@ import {
   pathExists,
 } from '@/main/util';
 
+// Configure Chrome/Electron flags for better memory management
+
+// Windows-specific, disables some fancy desktop window effects that can use a lot of memory
+app.commandLine.appendSwitch('disable-features', 'CalculateNativeWinOcclusion');
+
+// Prevent memory spikes from throttling when the app is in the background and moves to foreground
+app.commandLine.appendSwitch('disable-background-timer-throttling');
+
+// Keep renderer active when minimized to avoid memory spikes when restoring
+app.commandLine.appendSwitch('disable-renderer-backgrounding');
+
+// Remove limits on number of backing stores, which are per-window/tab. Theoretically, the launcher should only have two
+// windows open at a time so this should have no effect. But just in case, we disable the limit.
+app.commandLine.appendSwitch('disable-backing-store-limit');
+
 // Handle creating/removing shortcuts on Windows when installing/uninstalling.
 if (require('electron-squirrel-startup')) {
   app.quit();

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -61,9 +61,9 @@ main.ipc.handle('invoke-process:get-status', () => invoke.getStatus());
 /**
  * Cleans up any running processes (installation or invoke).
  */
-function cleanup() {
+async function cleanup() {
   cleanupInstall();
-  cleanupInvoke();
+  await cleanupInvoke();
   cleanupPty();
   main.cleanup();
 }

--- a/src/main/invoke-manager.ts
+++ b/src/main/invoke-manager.ts
@@ -190,6 +190,12 @@ export class InvokeManager {
       minHeight: 600,
       webPreferences: {
         devTools: true,
+        backgroundThrottling: false, // Prevent memory spikes from throttling when window loses focus
+        additionalArguments: [
+          '--enable-gpu-rasterization',      // Offload canvas to GPU
+          '--enable-zero-copy',              // Reduce memory copies
+          '--enable-accelerated-2d-canvas',  // GPU acceleration for 2D canvas
+        ],
       },
       autoHideMenuBar: true,
       frame: true,

--- a/src/main/invoke-manager.ts
+++ b/src/main/invoke-manager.ts
@@ -145,10 +145,10 @@ export class InvokeManager {
 
   startInvoke = async (location: string) => {
     this.updateStatus({ type: 'starting' });
-    
+
     // Clear logs from previous session
     this.sendClearLogs?.();
-    
+
     this.log.info('Starting up...\r\n');
 
     const dirDetails = await getInstallationDetails(location);

--- a/src/main/invoke-manager.ts
+++ b/src/main/invoke-manager.ts
@@ -351,6 +351,11 @@ export class InvokeManager {
         this.log.info(`[CRASH] Window can be reopened - server is still running\r\n`);
       }
 
+      // Close the crashed window (it may still be visible but unresponsive)
+      if (this.window && !this.window.isDestroyed()) {
+        this.window.destroy();
+      }
+
       // Clean up the window reference
       this.window = null;
       this.stopMetricsMonitoring();

--- a/src/main/invoke-manager.ts
+++ b/src/main/invoke-manager.ts
@@ -243,11 +243,11 @@ export class InvokeManager {
     window.webContents.loadURL(localUrl);
   };
 
-  exitInvoke = () => {
+  exitInvoke = async () => {
     this.log.info('Shutting down...\r\n');
     this.updateStatus({ type: 'exiting' });
     this.closeWindow();
-    this.killProcess();
+    await this.killProcess();
   };
 
   closeWindow = (): void => {
@@ -260,11 +260,11 @@ export class InvokeManager {
     this.window = null;
   };
 
-  killProcess = (): void => {
+  killProcess = async (): Promise<void> => {
     if (!this.process) {
       return;
     }
-    killProcess(this.process);
+    await killProcess(this.process);
   };
 }
 
@@ -295,10 +295,10 @@ export const createInvokeManager = (arg: {
     invokeManager.exitInvoke();
   });
 
-  const cleanupInvokeManager = () => {
+  const cleanupInvokeManager = async () => {
     const status = invokeManager.getStatus();
     if (status.type === 'running' || status.type === 'starting') {
-      invokeManager.exitInvoke();
+      await invokeManager.exitInvoke();
     }
     ipcMain.removeHandler('invoke-process:start-invoke');
     ipcMain.removeHandler('invoke-process:exit-invoke');

--- a/src/main/pty-manager.ts
+++ b/src/main/pty-manager.ts
@@ -11,7 +11,7 @@ export const createPtyManager = (arg: {
 }) => {
   const { ipc, sendToWindow } = arg;
   const options: PtyManager['options'] = {
-    maxHistorySize: 10_000,
+    maxHistorySize: 2_000,
   };
 
   const ptyManager = new PtyManager(options);

--- a/src/main/util.ts
+++ b/src/main/util.ts
@@ -272,7 +272,7 @@ export const killProcess = async (childProcess: ChildProcess): Promise<void> => 
     if (childProcess.killed || childProcess.exitCode !== null) {
       return false;
     }
-    
+
     try {
       // process.kill(pid, 0) checks if process exists without killing it
       // This can have false positives due to PID reuse, so we check childProcess.killed first
@@ -290,12 +290,12 @@ export const killProcess = async (childProcess: ChildProcess): Promise<void> => 
       const exitHandler = () => {
         resolve(true);
       };
-      
+
       // Try to attach exit handler if process is still alive
       if (!childProcess.killed) {
         childProcess.once('exit', exitHandler);
       }
-      
+
       const startTime = Date.now();
       const checkInterval = setInterval(() => {
         if (!isProcessRunning()) {
@@ -313,7 +313,7 @@ export const killProcess = async (childProcess: ChildProcess): Promise<void> => 
 
   if (process.platform === 'win32') {
     // Windows: Try graceful shutdown first, then escalate if needed
-    
+
     // Stage 1: Try graceful shutdown (sends WM_CLOSE)
     try {
       execFile('taskkill', ['/pid', pid.toString(), '/T'], (error) => {
@@ -322,7 +322,7 @@ export const killProcess = async (childProcess: ChildProcess): Promise<void> => 
           console.debug(`Graceful shutdown failed for PID ${pid}: ${error.message}`);
         }
       });
-      
+
       // Wait up to 5 seconds for graceful exit
       const exitedGracefully = await waitForExit(5000);
       if (exitedGracefully) {
@@ -336,7 +336,7 @@ export const killProcess = async (childProcess: ChildProcess): Promise<void> => 
     // Stage 2: Try Node's kill (might work for some processes)
     try {
       childProcess.kill('SIGTERM');
-      
+
       // Wait 2 more seconds
       const exitedWithSigterm = await waitForExit(2000);
       if (exitedWithSigterm) {
@@ -354,7 +354,7 @@ export const killProcess = async (childProcess: ChildProcess): Promise<void> => 
           console.error(`Force kill failed for PID ${pid}: ${error.message}`);
         }
       });
-      
+
       // Wait for force kill to complete
       const exitedForcefully = await waitForExit(2000);
       if (!exitedForcefully) {
@@ -368,7 +368,7 @@ export const killProcess = async (childProcess: ChildProcess): Promise<void> => 
   } else {
     // Unix-like systems: Use SIGTERM
     childProcess.kill('SIGTERM');
-    
+
     // Wait for process to exit
     const exited = await waitForExit(5000);
     if (!exited) {

--- a/src/renderer/features/Console/ConsoleXterm.tsx
+++ b/src/renderer/features/Console/ConsoleXterm.tsx
@@ -49,6 +49,7 @@ export const ConsoleXterm = memo(({ terminal }: { terminal: TerminalState }) => 
       for (const unsubscribe of subscriptions) {
         unsubscribe();
       }
+      terminal.xterm.dispose();
     };
   }, [terminal.fitAddon, terminal.id, terminal.xterm, theme]);
 

--- a/src/renderer/features/Console/state.ts
+++ b/src/renderer/features/Console/state.ts
@@ -9,7 +9,7 @@ const DEFAULT_XTERM_OPTIONS: ITerminalOptions & ITerminalInitOnlyOptions = {
   cursorBlink: true,
   fontSize: 12,
   fontFamily: 'JetBrainsMonoNerdFont, monospace',
-  scrollback: 10_000,
+  scrollback: 2_000,
   allowTransparency: true,
 };
 

--- a/src/renderer/features/InstallFlow/InstallFlowLogs.tsx
+++ b/src/renderer/features/InstallFlow/InstallFlowLogs.tsx
@@ -15,7 +15,12 @@ export const InstallFlowLogs = memo(() => {
   const installProcessStatus = useStore($installProcessStatus);
   return (
     <LogViewer logs={installProcessLogs}>
-      <LogViewerStatusIndicator isLoading={getIsActiveInstallProcessStatus(installProcessStatus)}>
+      <LogViewerStatusIndicator
+        isLoading={getIsActiveInstallProcessStatus(installProcessStatus)}
+        position="absolute"
+        top={2}
+        right={2}
+      >
         {startCase(installProcessStatus.type)}
       </LogViewerStatusIndicator>
     </LogViewer>

--- a/src/renderer/features/LaunchFlow/LaunchFlow.tsx
+++ b/src/renderer/features/LaunchFlow/LaunchFlow.tsx
@@ -7,7 +7,12 @@ import { LaunchFlowInvalidInstall } from '@/renderer/features/LaunchFlow/LaunchF
 import { LaunchFlowNotRunning } from '@/renderer/features/LaunchFlow/LaunchFlowNotRunning';
 import { LaunchFlowPendingDismissal } from '@/renderer/features/LaunchFlow/LaunchFlowPendingDismissal';
 import { LaunchFlowRunning } from '@/renderer/features/LaunchFlow/LaunchFlowRunning';
-import { $isInvokeProcessActive, $isInvokeProcessPendingDismissal } from '@/renderer/features/LaunchFlow/state';
+import { LaunchFlowWindowCrashed } from '@/renderer/features/LaunchFlow/LaunchFlowWindowCrashed';
+import {
+  $invokeProcessStatus,
+  $isInvokeProcessActive,
+  $isInvokeProcessPendingDismissal,
+} from '@/renderer/features/LaunchFlow/state';
 import { emitter } from '@/renderer/services/ipc';
 import type { DirDetails } from '@/shared/types';
 
@@ -16,8 +21,13 @@ type Props = {
 };
 
 const LaunchFlowContent = memo(({ installDirDetails }: Props) => {
+  const invokeProcessStatus = useStore($invokeProcessStatus);
   const isInvokeProcessActive = useStore($isInvokeProcessActive);
   const isInvokeProcessPendingDismissal = useStore($isInvokeProcessPendingDismissal);
+
+  if (invokeProcessStatus.type === 'window-crashed') {
+    return <LaunchFlowWindowCrashed />;
+  }
 
   if (isInvokeProcessActive) {
     return <LaunchFlowRunning />;

--- a/src/renderer/features/LaunchFlow/LaunchFlowLogViewer.tsx
+++ b/src/renderer/features/LaunchFlow/LaunchFlowLogViewer.tsx
@@ -7,6 +7,7 @@ import {
   $invokeProcessStatus,
   getIsInvokeProcessActive,
 } from '@/renderer/features/LaunchFlow/state';
+import { UIMemoryMonitor } from '@/renderer/features/LaunchFlow/UIMemoryMonitor';
 import { LogViewer } from '@/renderer/features/LogViewer/LogViewer';
 import { LogViewerStatusIndicator } from '@/renderer/features/LogViewer/LogViewerStatusIndicator';
 import type { InvokeProcessStatus } from '@/shared/types';
@@ -24,7 +25,13 @@ export const LaunchFlowLogViewer = memo(() => {
 
   return (
     <LogViewer logs={invokeProcessLogs}>
-      <LogViewerStatusIndicator isLoading={getIsInvokeProcessActive(invokeProcessStatus)}>
+      <UIMemoryMonitor position="absolute" top={2} left={2} />
+      <LogViewerStatusIndicator
+        isLoading={getIsInvokeProcessActive(invokeProcessStatus)}
+        position="absolute"
+        top={2}
+        right={2}
+      >
         {getMessage(invokeProcessStatus)}
       </LogViewerStatusIndicator>
     </LogViewer>

--- a/src/renderer/features/LaunchFlow/LaunchFlowWindowCrashed.tsx
+++ b/src/renderer/features/LaunchFlow/LaunchFlowWindowCrashed.tsx
@@ -1,0 +1,39 @@
+import { Button, Heading, Text, VStack } from '@invoke-ai/ui-library';
+import { memo } from 'react';
+
+import { BodyContainer, BodyContent, BodyFooter } from '@/renderer/common/layout';
+import { LaunchFlowLogViewer } from '@/renderer/features/LaunchFlow/LaunchFlowLogViewer';
+import { emitter } from '@/renderer/services/ipc';
+
+const reopenWindow = async () => {
+  await emitter.invoke('invoke-process:reopen-window');
+};
+
+const quit = async () => {
+  await emitter.invoke('invoke-process:exit-invoke');
+};
+
+export const LaunchFlowWindowCrashed = memo(() => {
+  return (
+    <BodyContainer>
+      <BodyContent>
+        <VStack gap={4} alignItems="center" justifyContent="center" h="full">
+          <Heading size="lg">Window Crashed</Heading>
+          <Text color="base.300">The Invoke UI window closed unexpectedly, but the server is still running.</Text>
+          <Text color="base.300">You can reopen the window or shutdown the server.</Text>
+        </VStack>
+        <LaunchFlowLogViewer />
+      </BodyContent>
+      <BodyFooter>
+        <Button onClick={reopenWindow} colorScheme="invokeGreen">
+          Reopen Window
+        </Button>
+        <Button onClick={quit} colorScheme="error">
+          Shutdown Server
+        </Button>
+      </BodyFooter>
+    </BodyContainer>
+  );
+});
+
+LaunchFlowWindowCrashed.displayName = 'LaunchFlowWindowCrashed';

--- a/src/renderer/features/LaunchFlow/UIMemoryMonitor.tsx
+++ b/src/renderer/features/LaunchFlow/UIMemoryMonitor.tsx
@@ -1,0 +1,47 @@
+import type { BoxProps } from '@invoke-ai/ui-library';
+import { Flex, Text } from '@invoke-ai/ui-library';
+import { useStore } from '@nanostores/react';
+import { filesize } from 'filesize';
+import { useEffect, useState } from 'react';
+
+import { ipc } from '@/renderer/services/ipc';
+import { persistedStoreApi } from '@/renderer/services/store';
+
+const FOUR_GB_IN_BYTES = 4 * 1024 * 1024 * 1024;
+const THRESHOLD = FOUR_GB_IN_BYTES * 0.9;
+
+export const UIMemoryMonitor = (props: BoxProps) => {
+  const [metrics, setMetrics] = useState<{ memoryBytes: number; cpuPercent: number } | null>(null);
+  const { showUIWindowMemoryMonitor } = useStore(persistedStoreApi.$atom);
+
+  useEffect(() => {
+    const unsubscribe = ipc.on('invoke-process:metrics', (e, metrics) => {
+      setMetrics(metrics);
+    });
+
+    return unsubscribe;
+  }, []);
+
+  if (!metrics || !showUIWindowMemoryMonitor) {
+    return null;
+  }
+
+  return (
+    <Flex
+      gap={2}
+      bg="base.900"
+      borderRadius="base"
+      userSelect="none"
+      px={3}
+      py={1}
+      opacity={0.8}
+      borderWidth={1}
+      shadow="dark-lg"
+      {...props}
+    >
+      <Text color={metrics.memoryBytes > THRESHOLD ? 'error.300' : undefined}>
+        UI Memory: {filesize(metrics.memoryBytes)}
+      </Text>
+    </Flex>
+  );
+};

--- a/src/renderer/features/LaunchFlow/state.ts
+++ b/src/renderer/features/LaunchFlow/state.ts
@@ -42,7 +42,7 @@ const appendToInvokeProcessLogs = (entry: WithTimestamp<LogEntry>) => {
   $invokeProcessLogs.set([...invokeLogBuffer.get()]);
 };
 
-export const clearInvokeProcessLogs = () => {
+const clearInvokeProcessLogs = () => {
   invokeLogBuffer.clear();
   $invokeProcessLogs.set([]);
 };

--- a/src/renderer/features/LaunchFlow/state.ts
+++ b/src/renderer/features/LaunchFlow/state.ts
@@ -42,6 +42,11 @@ const appendToInvokeProcessLogs = (entry: WithTimestamp<LogEntry>) => {
   $invokeProcessLogs.set([...invokeLogBuffer.get()]);
 };
 
+export const clearInvokeProcessLogs = () => {
+  invokeLogBuffer.clear();
+  $invokeProcessLogs.set([]);
+};
+
 const listen = () => {
   const buffer = new LineBuffer({ stripAnsi: true });
 
@@ -50,6 +55,10 @@ const listen = () => {
     for (const message of buffered) {
       appendToInvokeProcessLogs({ ...data, message });
     }
+  });
+
+  ipc.on('invoke-process:clear-logs', () => {
+    clearInvokeProcessLogs();
   });
 
   ipc.on('invoke-process:status', (_, status) => {

--- a/src/renderer/features/LogViewer/LogViewerStatusIndicator.tsx
+++ b/src/renderer/features/LogViewer/LogViewerStatusIndicator.tsx
@@ -1,4 +1,4 @@
-import type { SystemStyleObject, TextProps } from '@invoke-ai/ui-library';
+import type { BoxProps, SystemStyleObject } from '@invoke-ai/ui-library';
 import { Box, Text } from '@invoke-ai/ui-library';
 import Linkify from 'linkify-react';
 import type { Opts as LinkifyOpts } from 'linkifyjs';
@@ -23,14 +23,11 @@ const linkifyOptions: LinkifyOpts = {
 
 type Props = {
   isLoading: boolean;
-} & TextProps;
+} & BoxProps;
 
-export const LogViewerStatusIndicator = ({ isLoading, children, ...textProps }: Props) => {
+export const LogViewerStatusIndicator = ({ isLoading, children, ...boxProps }: Props) => {
   return (
     <Box
-      position="absolute"
-      top={2}
-      right={2}
       bg="base.900"
       borderRadius="base"
       userSelect="none"
@@ -39,8 +36,9 @@ export const LogViewerStatusIndicator = ({ isLoading, children, ...textProps }: 
       opacity={0.8}
       borderWidth={1}
       shadow="dark-lg"
+      {...boxProps}
     >
-      <Text sx={sx} data-loading={isLoading} {...textProps}>
+      <Text sx={sx} data-loading={isLoading}>
         <Linkify options={linkifyOptions}>{children}</Linkify>
       </Text>
     </Box>

--- a/src/renderer/features/SettingsModal/SettingsModal.tsx
+++ b/src/renderer/features/SettingsModal/SettingsModal.tsx
@@ -19,6 +19,8 @@ import { SettingsModalResetButton } from '@/renderer/features/SettingsModal/Sett
 import { SettingsModalServerMode } from '@/renderer/features/SettingsModal/SettingsModalServerMode';
 import { $isSettingsOpen } from '@/renderer/features/SettingsModal/state';
 
+import { SettingsModalShowUIWindowMemoryMonitor } from './SettingsModalShowUIWindowMemoryMonitor';
+
 export const SettingsModal = memo(() => {
   const isOpen = useStore($isSettingsOpen);
   const onClose = useCallback(() => {
@@ -34,6 +36,8 @@ export const SettingsModal = memo(() => {
         <ModalCloseButton />
         <ModalBody as={Flex} flexDir="column" gap={4} w="full" h="full" minH={32}>
           <SettingsModalServerMode />
+          <Divider />
+          <SettingsModalShowUIWindowMemoryMonitor />
           <Divider />
           <SettingsModalNotifyForPrereleaseUpdates />
         </ModalBody>

--- a/src/renderer/features/SettingsModal/SettingsModalShowUIWindowMemoryMonitor.tsx
+++ b/src/renderer/features/SettingsModal/SettingsModalShowUIWindowMemoryMonitor.tsx
@@ -1,0 +1,25 @@
+import { Checkbox, Flex, FormControl, FormHelperText, FormLabel } from '@invoke-ai/ui-library';
+import { useStore } from '@nanostores/react';
+import { memo, useCallback } from 'react';
+
+import { persistedStoreApi } from '@/renderer/services/store';
+
+export const SettingsModalShowUIWindowMemoryMonitor = memo(() => {
+  const { showUIWindowMemoryMonitor } = useStore(persistedStoreApi.$atom);
+  const onChange = useCallback(() => {
+    persistedStoreApi.setKey('showUIWindowMemoryMonitor', !persistedStoreApi.$atom.get().showUIWindowMemoryMonitor);
+  }, []);
+
+  return (
+    <FormControl orientation="vertical">
+      <Flex w="full" alignItems="center" justifyContent="space-between">
+        <FormLabel>Show UI Window Memory Monitor</FormLabel>
+        <Checkbox isChecked={showUIWindowMemoryMonitor} onChange={onChange} />
+      </Flex>
+      <FormHelperText>
+        Display memory and CPU usage of the Invoke UI Window in the top-left corner of the app log viewer.
+      </FormHelperText>
+    </FormControl>
+  );
+});
+SettingsModalShowUIWindowMemoryMonitor.displayName = 'SettingsModalShowUIWindowMemoryMonitor';

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -234,6 +234,21 @@ export type InvokeProcessStatus =
          */
         url: string;
       }
+    >
+  | OkStatus<
+      'window-crashed',
+      {
+        /**
+         * The URL at which the server is still running. The process is alive but the window crashed.
+         */
+        loopbackUrl: string;
+        lanUrl?: string;
+        url: string;
+        /**
+         * The reason for the crash if available.
+         */
+        crashReason?: string;
+      }
     >;
 
 /**
@@ -314,6 +329,7 @@ type InvokeProcessIpcEvents = Namespaced<
     'get-status': () => WithTimestamp<InvokeProcessStatus>;
     'start-invoke': (location: string) => void;
     'exit-invoke': () => void;
+    'reopen-window': () => void;
   }
 >;
 

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -428,6 +428,7 @@ type InvokeProcessIpcRendererEvents = Namespaced<
     status: [WithTimestamp<InvokeProcessStatus>];
     log: [WithTimestamp<LogEntry>];
     metrics: [{ memoryBytes: number; cpuPercent: number }];
+    'clear-logs': [];
   }
 >;
 

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -51,6 +51,7 @@ export type StoreData = {
   notifyForPrereleaseUpdates: boolean;
   launcherWindowProps?: WindowProps;
   appWindowProps?: WindowProps;
+  showUIWindowMemoryMonitor?: boolean;
 };
 
 // The electron store uses JSON schema to validate its data.
@@ -410,6 +411,7 @@ type InvokeProcessIpcRendererEvents = Namespaced<
   {
     status: [WithTimestamp<InvokeProcessStatus>];
     log: [WithTimestamp<LogEntry>];
+    metrics: [{ memoryBytes: number; cpuPercent: number }];
   }
 >;
 


### PR DESCRIPTION
Handful of changes to reduce memory usage and handle OOMs more gracefully.

- Set a few Chrome/V8 flags to hopefully reduce memory usage. Notably, enabling GPU for some things.
- Fix a potential (very minor) memory leak with xterm not getting disposed of properly.
- Reduce scrollback for log viewers from 10k to 2k lines.
- Optimize log viewer append logic to reduce number of new arrays created and reduce react renders.
- When shutting down, handling it a bit more gracefully for Windows. Previously it was rather brutal, force-killing the process.
- Take simple memory snapshots of the UI window (not Invoke - only the chrome electron window) every second and emit this information to the renderer process. A new setting enables a simple monitor display. The monitor turns red when memory usage hits 90%. 
- When the UI window crashes, log some descriptive error messages. It does its best to understand the reason for the crash but it's not perfect. Electron provides an "oom" reason but that reason doesn't seem to work for me on macOS - I think Chrome is detecting that it is about to OOM and ending the process itself rather than hit the OOM.
- When the UI window crashes, we detect this and show an alert and button to reopen the window.

---

To trigger the electron memory limit:
- Start Invoke w/ electron window
- Open the dev tools and go to JS console
- Paste this command, which will allocate a crapload of memory:
    ```js
    let arr = [];
    while(true) {
      arr.push(new Array(1000000).fill('x'.repeat(1000)));
    }
    ```
- Watch the memory usage climb, go red, and the UI crash just after 4GB (the hardcoded Electron memory limit)

Example UX:
<video src="https://github.com/user-attachments/assets/1e4279aa-8084-4530-bb00-2cddb93bcf0d"></video>




