### PR TITLE
feat: use `shell-env` to grab user-defined env vars when running Launcher as GUI app

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -74,6 +74,7 @@
         "react-icons": "^5.5.0",
         "rimraf": "^6.0.1",
         "serialize-error": "^12.0.0",
+        "shell-env": "^4.0.1",
         "strip-ansi": "^7.1.0",
         "tar": "^7.4.3",
         "tmp": "^0.2.3",
@@ -6735,67 +6736,17 @@
         "node": ">= 10"
       }
     },
-    "node_modules/default-gateway/node_modules/execa": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
-      "integrity": "sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "cross-spawn": "^7.0.3",
-        "get-stream": "^6.0.0",
-        "human-signals": "^2.1.0",
-        "is-stream": "^2.0.0",
-        "merge-stream": "^2.0.0",
-        "npm-run-path": "^4.0.1",
-        "onetime": "^5.1.2",
-        "signal-exit": "^3.0.3",
-        "strip-final-newline": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sindresorhus/execa?sponsor=1"
-      }
-    },
-    "node_modules/default-gateway/node_modules/get-stream": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
-      "integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
+    "node_modules/default-shell": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/default-shell/-/default-shell-2.2.0.tgz",
+      "integrity": "sha512-sPpMZcVhRQ0nEMDtuMJ+RtCxt7iHPAMBU+I4tAlo5dU1sjRpNax0crj6nR3qKpvVnckaQ9U38enXcwW9nZJeCw==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=10"
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/default-gateway/node_modules/is-stream": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
-      "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/default-gateway/node_modules/npm-run-path": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
-      "integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "path-key": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/defaults": {
@@ -8474,6 +8425,69 @@
       "devOptional": true,
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/execa": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
+      "integrity": "sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cross-spawn": "^7.0.3",
+        "get-stream": "^6.0.0",
+        "human-signals": "^2.1.0",
+        "is-stream": "^2.0.0",
+        "merge-stream": "^2.0.0",
+        "npm-run-path": "^4.0.1",
+        "onetime": "^5.1.2",
+        "signal-exit": "^3.0.3",
+        "strip-final-newline": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/execa?sponsor=1"
+      }
+    },
+    "node_modules/execa/node_modules/get-stream": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
+      "integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/execa/node_modules/is-stream": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
+      "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/execa/node_modules/npm-run-path": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
+      "integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/expect-type": {
@@ -13678,6 +13692,24 @@
       "devOptional": true,
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/shell-env": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/shell-env/-/shell-env-4.0.1.tgz",
+      "integrity": "sha512-w3oeZ9qg/P6Lu6qqwavvMnB/bwfsz67gPB3WXmLd/n6zuh7TWQZtGa3iMEdmua0kj8rivkwl+vUjgLWlqZOMPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "default-shell": "^2.0.0",
+        "execa": "^5.1.1",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/shell-quote": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "invoke-community-edition",
-  "version": "1.7.0",
+  "version": "1.7.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "invoke-community-edition",
-      "version": "1.7.0",
+      "version": "1.7.1",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "invoke-community-edition",
   "productName": "Invoke Community Edition",
-  "version": "1.7.0",
+  "version": "1.7.1",
   "description": "Invoke Community Edition",
   "main": "out/main/index.js",
   "engines": {

--- a/package.json
+++ b/package.json
@@ -97,6 +97,7 @@
     "react-icons": "^5.5.0",
     "rimraf": "^6.0.1",
     "serialize-error": "^12.0.0",
+    "shell-env": "^4.0.1",
     "strip-ansi": "^7.1.0",
     "tar": "^7.4.3",
     "tmp": "^0.2.3",

--- a/src/main/install-manager.ts
+++ b/src/main/install-manager.ts
@@ -5,6 +5,7 @@ import { ipcMain } from 'electron';
 import fs from 'fs/promises';
 import path, { join } from 'path';
 import { serializeError } from 'serialize-error';
+import { shellEnvSync } from 'shell-env';
 import { assert } from 'tsafe';
 
 import { CommandRunner } from '@/lib/command-runner';
@@ -252,7 +253,7 @@ export class InstallManager {
     }
 
     const runProcessOptions = {
-      env: { ...process.env, ...DEFAULT_ENV } as Record<string, string>,
+      env: { ...process.env, ...DEFAULT_ENV, ...shellEnvSync() } as Record<string, string>,
     };
 
     if (repair || pythonVersionMismatch) {

--- a/src/main/invoke-manager.ts
+++ b/src/main/invoke-manager.ts
@@ -5,6 +5,7 @@ import type Store from 'electron-store';
 import fs from 'fs/promises';
 import ip from 'ip';
 import { join } from 'path';
+import { shellEnvSync } from 'shell-env';
 
 import { CommandRunner } from '@/lib/command-runner';
 import { DEFAULT_ENV } from '@/lib/pty-utils';
@@ -100,7 +101,7 @@ export class InvokeManager {
       this.log.info(c.magenta.bold('Preparing first run of this install - may take a minute or two...\r\n'));
     }
 
-    const env: Record<string, string> = { ...process.env, INVOKEAI_ROOT: location, ...DEFAULT_ENV };
+    const env: Record<string, string> = { ...process.env, INVOKEAI_ROOT: location, ...DEFAULT_ENV, ...shellEnvSync() };
 
     // If server mode is enabled, set the host to 0.0.0.0 to enable LAN access
     if (this.store.get('serverMode')) {


### PR DESCRIPTION
- Closes #111
- Bump version to v1.7.1