### PR TITLE
fix(windows): use WinTab for pen contact while preserving mouse-mapped stylus buttons

### DIFF
--- a/electron-builder.config.ts
+++ b/electron-builder.config.ts
@@ -22,7 +22,7 @@ export default {
   directories: {
     output: 'dist',
   },
-  files: ['package.json', 'out/**/*', 'node_modules/node-pty/**/*'],
+  files: ['package.json', 'out/**/*', 'node_modules/node-pty/**/*', 'node_modules/wintab-pen-bridge/**/*'],
   extraResources: [
     {
       from: 'assets/bin',

--- a/electron.vite.config.ts
+++ b/electron.vite.config.ts
@@ -12,7 +12,7 @@ export default defineConfig({
         entry: resolve('src/main/index.ts'),
       },
       rollupOptions: {
-        external: ['node-pty'],
+        external: ['node-pty', 'wintab-pen-bridge'],
       },
     },
   },

--- a/native/wintab-pen-bridge/binding.gyp
+++ b/native/wintab-pen-bridge/binding.gyp
@@ -1,0 +1,24 @@
+{
+  "targets": [
+    {
+      "target_name": "wintab_pen_bridge",
+      "sources": [
+        "src/wintab_pen_bridge.cc"
+      ],
+      "defines": [
+        "NAPI_VERSION=8",
+        "UNICODE",
+        "_UNICODE",
+        "WIN32_LEAN_AND_MEAN",
+        "NOMINMAX"
+      ],
+      "msvs_settings": {
+        "VCCLCompilerTool": {
+          "AdditionalOptions": [
+            "/std:c++20"
+          ]
+        }
+      }
+    }
+  ]
+}

--- a/native/wintab-pen-bridge/index.js
+++ b/native/wintab-pen-bridge/index.js
@@ -1,0 +1,5 @@
+/* eslint-disable @typescript-eslint/no-require-imports */
+'use strict';
+
+module.exports = require('./build/Release/wintab_pen_bridge.node');
+

--- a/native/wintab-pen-bridge/index.js
+++ b/native/wintab-pen-bridge/index.js
@@ -2,4 +2,3 @@
 'use strict';
 
 module.exports = require('./build/Release/wintab_pen_bridge.node');
-

--- a/native/wintab-pen-bridge/package.json
+++ b/native/wintab-pen-bridge/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "wintab-pen-bridge",
+  "version": "0.0.1",
+  "description": "Windows-only WinTab pen bridge for Invoke Launcher",
+  "main": "index.js",
+  "gypfile": true,
+  "private": true,
+  "os": [
+    "win32"
+  ],
+  "scripts": {
+    "install": "node-gyp rebuild"
+  }
+}

--- a/native/wintab-pen-bridge/src/wintab_pen_bridge.cc
+++ b/native/wintab-pen-bridge/src/wintab_pen_bridge.cc
@@ -1,0 +1,598 @@
+#include <node_api.h>
+
+#include <windows.h>
+
+#include <algorithm>
+#include <cmath>
+#include <cstdint>
+#include <cstring>
+#include <deque>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+namespace {
+
+using WTPKT = UINT;
+using HCTX = HANDLE;
+
+struct FIX32 {
+  WORD frac;
+  short whole;
+};
+
+struct AXIS {
+  LONG axMin;
+  LONG axMax;
+  UINT axUnits;
+  FIX32 axResolution;
+};
+
+struct LOGCONTEXTW {
+  WCHAR lcName[40];
+  UINT lcOptions;
+  UINT lcStatus;
+  UINT lcLocks;
+  UINT lcMsgBase;
+  UINT lcDevice;
+  UINT lcPktRate;
+  WTPKT lcPktData;
+  WTPKT lcPktMode;
+  WTPKT lcMoveMask;
+  DWORD lcBtnDnMask;
+  DWORD lcBtnUpMask;
+  LONG lcInOrgX;
+  LONG lcInOrgY;
+  LONG lcInOrgZ;
+  LONG lcInExtX;
+  LONG lcInExtY;
+  LONG lcInExtZ;
+  LONG lcOutOrgX;
+  LONG lcOutOrgY;
+  LONG lcOutOrgZ;
+  LONG lcOutExtX;
+  LONG lcOutExtY;
+  LONG lcOutExtZ;
+  FIX32 lcSensX;
+  FIX32 lcSensY;
+  FIX32 lcSensZ;
+  BOOL lcSysMode;
+  int lcSysOrgX;
+  int lcSysOrgY;
+  int lcSysExtX;
+  int lcSysExtY;
+  FIX32 lcSysSensX;
+  FIX32 lcSysSensY;
+};
+
+struct PacketData {
+  HCTX pkContext;
+  UINT pkStatus;
+  DWORD pkButtons;
+  LONG pkX;
+  LONG pkY;
+  UINT pkNormalPressure;
+};
+
+constexpr UINT WTI_INTERFACE = 1;
+constexpr UINT WTI_DEFCONTEXT = 3;
+constexpr UINT WTI_DEFSYSCTX = 4;
+constexpr UINT WTI_DEVICES = 100;
+constexpr UINT DVC_NPRESSURE = 15;
+
+constexpr UINT CXO_MESSAGES = 0x0004;
+
+constexpr UINT WT_DEFBASE = 0x7FF0;
+constexpr UINT WT_PACKET = 0;
+
+constexpr WTPKT PK_CONTEXT = 0x0001;
+constexpr WTPKT PK_STATUS = 0x0002;
+constexpr WTPKT PK_BUTTONS = 0x0040;
+constexpr WTPKT PK_X = 0x0080;
+constexpr WTPKT PK_Y = 0x0100;
+constexpr WTPKT PK_NORMAL_PRESSURE = 0x0400;
+
+using WTInfoW_t = UINT(APIENTRY *)(UINT, UINT, LPVOID);
+using WTOpenW_t = HCTX(APIENTRY *)(HWND, LOGCONTEXTW *, BOOL);
+using WTClose_t = BOOL(APIENTRY *)(HCTX);
+using WTPacketsGet_t = int(APIENTRY *)(HCTX, int, LPVOID);
+using WTEnable_t = BOOL(APIENTRY *)(HCTX, BOOL);
+using WTOverlap_t = BOOL(APIENTRY *)(HCTX, BOOL);
+
+struct WinTabApi {
+  HMODULE module = nullptr;
+  WTInfoW_t WTInfoW = nullptr;
+  WTOpenW_t WTOpenW = nullptr;
+  WTClose_t WTClose = nullptr;
+  WTPacketsGet_t WTPacketsGet = nullptr;
+  WTEnable_t WTEnable = nullptr;
+  WTOverlap_t WTOverlap = nullptr;
+};
+
+struct PenEvent {
+  enum class Kind { Down, Move, Up };
+
+  Kind kind;
+  LONG screenX;
+  LONG screenY;
+  double pressure;
+  DWORD buttons;
+};
+
+struct BridgeState {
+  WinTabApi api;
+  HWND hwnd = nullptr;
+  HCTX context = nullptr;
+  UINT msgBase = WT_DEFBASE;
+  LONG pressureMin = 0;
+  LONG pressureMax = 1023;
+  bool attached = false;
+  bool contactActive = false;
+  ULONGLONG suppressPrimaryMouseUntil = 0;
+  LONG lastScreenX = 0;
+  LONG lastScreenY = 0;
+  double lastPressure = 0.0;
+  DWORD lastButtons = 0;
+  std::wstring lastError;
+  std::deque<PenEvent> queuedEvents;
+  std::unordered_map<HWND, WNDPROC> hookedWindows;
+};
+
+BridgeState g_bridge;
+
+void ProcessPacket(const PacketData &packet);
+
+void SetLastErrorMessage(const std::wstring &message) {
+  g_bridge.lastError = message;
+}
+
+bool EnsureWinTabLoaded() {
+  if (g_bridge.api.module != nullptr) {
+    return true;
+  }
+
+  HMODULE module = LoadLibraryW(L"Wintab32.dll");
+  if (module == nullptr) {
+    SetLastErrorMessage(L"Failed to load Wintab32.dll");
+    return false;
+  }
+
+  auto loadProc = [module](auto &target, const char *name) -> bool {
+    target = reinterpret_cast<std::remove_reference_t<decltype(target)>>(GetProcAddress(module, name));
+    return target != nullptr;
+  };
+
+  if (!loadProc(g_bridge.api.WTInfoW, "WTInfoW") || !loadProc(g_bridge.api.WTOpenW, "WTOpenW") ||
+      !loadProc(g_bridge.api.WTClose, "WTClose") || !loadProc(g_bridge.api.WTPacketsGet, "WTPacketsGet") ||
+      !loadProc(g_bridge.api.WTEnable, "WTEnable") || !loadProc(g_bridge.api.WTOverlap, "WTOverlap")) {
+    FreeLibrary(module);
+    SetLastErrorMessage(L"Failed to load one or more WinTab entry points");
+    return false;
+  }
+
+  g_bridge.api.module = module;
+  return true;
+}
+
+double NormalizePressure(UINT pressure) {
+  const auto range = static_cast<double>(std::max<LONG>(1, g_bridge.pressureMax - g_bridge.pressureMin));
+  const auto normalized = (static_cast<double>(pressure) - static_cast<double>(g_bridge.pressureMin)) / range;
+  return std::clamp(normalized, 0.0, 1.0);
+}
+
+void QueuePenEvent(PenEvent::Kind kind, LONG screenX, LONG screenY, double pressure, DWORD buttons) {
+  g_bridge.queuedEvents.push_back(PenEvent{kind, screenX, screenY, pressure, buttons});
+}
+
+POINT ResolveCursorScreenPoint(const PacketData &packet) {
+  POINT point{packet.pkX, packet.pkY};
+  if (GetCursorPos(&point)) {
+    return point;
+  }
+  return point;
+}
+
+bool IsPointerMessage(const UINT message) {
+  switch (message) {
+    case WM_POINTERDOWN:
+    case WM_POINTERUP:
+    case WM_POINTERUPDATE:
+    case WM_POINTERENTER:
+    case WM_POINTERLEAVE:
+    case WM_POINTERACTIVATE:
+    case WM_POINTERCAPTURECHANGED:
+    case WM_POINTERWHEEL:
+    case WM_POINTERHWHEEL:
+      return true;
+    default:
+      return false;
+  }
+}
+
+bool ShouldSuppressPenPointerMessage(const UINT message, const WPARAM wParam) {
+  if (!IsPointerMessage(message)) {
+    return false;
+  }
+
+  const UINT32 pointerId = GET_POINTERID_WPARAM(wParam);
+  POINTER_INPUT_TYPE pointerType = PT_POINTER;
+  if (!GetPointerType(pointerId, &pointerType)) {
+    return false;
+  }
+
+  return pointerType == PT_PEN;
+}
+
+bool ShouldSuppressPrimaryMousePathNow() {
+  return g_bridge.contactActive || GetTickCount64() <= g_bridge.suppressPrimaryMouseUntil;
+}
+
+bool ShouldSuppressPrimaryMouseMessage(const UINT message) {
+  if (!ShouldSuppressPrimaryMousePathNow()) {
+    return false;
+  }
+
+  switch (message) {
+    case WM_LBUTTONDOWN:
+    case WM_LBUTTONUP:
+    case WM_LBUTTONDBLCLK:
+    case WM_MOUSEMOVE:
+      return true;
+    default:
+      return false;
+  }
+}
+
+void ProcessQueuedPackets() {
+  if (g_bridge.context == nullptr) {
+    return;
+  }
+
+  PacketData packets[32];
+  const int packetCount = g_bridge.api.WTPacketsGet(g_bridge.context, 32, packets);
+  for (int index = 0; index < packetCount; ++index) {
+    ProcessPacket(packets[index]);
+  }
+}
+
+void ProcessPacket(const PacketData &packet) {
+  const auto pressure = NormalizePressure(packet.pkNormalPressure);
+  const bool contact = pressure > 0.0 || (packet.pkButtons & 0x1U) != 0;
+  const POINT cursorPoint = ResolveCursorScreenPoint(packet);
+
+  if (!g_bridge.contactActive && contact) {
+    g_bridge.contactActive = true;
+    g_bridge.suppressPrimaryMouseUntil = 0;
+    g_bridge.lastScreenX = cursorPoint.x;
+    g_bridge.lastScreenY = cursorPoint.y;
+    g_bridge.lastPressure = pressure;
+    g_bridge.lastButtons = packet.pkButtons;
+    QueuePenEvent(PenEvent::Kind::Down, cursorPoint.x, cursorPoint.y, pressure, packet.pkButtons);
+    return;
+  }
+
+  if (g_bridge.contactActive && contact) {
+    const bool changed = cursorPoint.x != g_bridge.lastScreenX || cursorPoint.y != g_bridge.lastScreenY ||
+                         std::fabs(pressure - g_bridge.lastPressure) > 0.0001 ||
+                         packet.pkButtons != g_bridge.lastButtons;
+    g_bridge.lastScreenX = cursorPoint.x;
+    g_bridge.lastScreenY = cursorPoint.y;
+    g_bridge.lastPressure = pressure;
+    g_bridge.lastButtons = packet.pkButtons;
+    if (changed) {
+      QueuePenEvent(PenEvent::Kind::Move, cursorPoint.x, cursorPoint.y, pressure, packet.pkButtons);
+    }
+    return;
+  }
+
+  if (g_bridge.contactActive && !contact) {
+    g_bridge.contactActive = false;
+    g_bridge.suppressPrimaryMouseUntil = GetTickCount64() + 200;
+    g_bridge.lastScreenX = cursorPoint.x;
+    g_bridge.lastScreenY = cursorPoint.y;
+    g_bridge.lastPressure = 0.0;
+    g_bridge.lastButtons = packet.pkButtons;
+    QueuePenEvent(PenEvent::Kind::Up, cursorPoint.x, cursorPoint.y, 0.0, packet.pkButtons);
+  }
+}
+
+bool HookWindow(HWND hwnd);
+
+BOOL CALLBACK HookChildWindowProc(HWND hwnd, LPARAM) {
+  HookWindow(hwnd);
+  return TRUE;
+}
+
+void HookWindowTree(HWND hwnd) {
+  if (hwnd == nullptr || !IsWindow(hwnd)) {
+    return;
+  }
+
+  HookWindow(hwnd);
+  EnumChildWindows(hwnd, HookChildWindowProc, 0);
+}
+
+LRESULT CallOriginalWindowProc(HWND hwnd, UINT message, WPARAM wParam, LPARAM lParam) {
+  const auto iterator = g_bridge.hookedWindows.find(hwnd);
+  if (iterator != g_bridge.hookedWindows.end() && iterator->second != nullptr) {
+    return CallWindowProcW(iterator->second, hwnd, message, wParam, lParam);
+  }
+
+  return DefWindowProcW(hwnd, message, wParam, lParam);
+}
+
+LRESULT CALLBACK HookWndProc(HWND hwnd, UINT message, WPARAM wParam, LPARAM lParam) {
+  if (g_bridge.attached) {
+    if (message == g_bridge.msgBase + WT_PACKET) {
+      ProcessQueuedPackets();
+    }
+
+    if (message == WM_PARENTNOTIFY && LOWORD(wParam) == WM_CREATE) {
+      const auto childHwnd = reinterpret_cast<HWND>(lParam);
+      HookWindowTree(childHwnd);
+    }
+
+    if (ShouldSuppressPenPointerMessage(message, wParam) || ShouldSuppressPrimaryMouseMessage(message)) {
+      return 0;
+    }
+  }
+
+  const LRESULT result = CallOriginalWindowProc(hwnd, message, wParam, lParam);
+
+  if (message == WM_NCDESTROY) {
+    g_bridge.hookedWindows.erase(hwnd);
+    if (hwnd == g_bridge.hwnd) {
+      g_bridge.hwnd = nullptr;
+    }
+  }
+
+  return result;
+}
+
+bool HookWindow(HWND hwnd) {
+  if (hwnd == nullptr || !IsWindow(hwnd)) {
+    return false;
+  }
+
+  if (g_bridge.hookedWindows.contains(hwnd)) {
+    return true;
+  }
+
+  SetLastError(0);
+  const auto previousProc = reinterpret_cast<WNDPROC>(
+      SetWindowLongPtrW(hwnd, GWLP_WNDPROC, reinterpret_cast<LONG_PTR>(HookWndProc)));
+  if (previousProc == nullptr && GetLastError() != 0) {
+    return false;
+  }
+
+  g_bridge.hookedWindows.emplace(hwnd, previousProc);
+  return true;
+}
+
+void DetachInternal() {
+  if (g_bridge.context != nullptr) {
+    g_bridge.api.WTClose(g_bridge.context);
+    g_bridge.context = nullptr;
+  }
+
+  std::vector<std::pair<HWND, WNDPROC>> hookedWindows(g_bridge.hookedWindows.begin(), g_bridge.hookedWindows.end());
+  for (const auto &[hwnd, originalProc] : hookedWindows) {
+    if (hwnd != nullptr && originalProc != nullptr && IsWindow(hwnd)) {
+      SetWindowLongPtrW(hwnd, GWLP_WNDPROC, reinterpret_cast<LONG_PTR>(originalProc));
+    }
+  }
+  g_bridge.hookedWindows.clear();
+
+  g_bridge.hwnd = nullptr;
+  g_bridge.attached = false;
+  g_bridge.contactActive = false;
+  g_bridge.suppressPrimaryMouseUntil = 0;
+  g_bridge.lastPressure = 0.0;
+  g_bridge.lastButtons = 0;
+  g_bridge.queuedEvents.clear();
+}
+
+bool AttachInternal(HWND hwnd) {
+  if (hwnd == nullptr) {
+    SetLastErrorMessage(L"Invalid window handle");
+    return false;
+  }
+
+  if (!EnsureWinTabLoaded()) {
+    return false;
+  }
+
+  if (g_bridge.attached) {
+    DetachInternal();
+  }
+
+  LOGCONTEXTW context{};
+  const UINT size = g_bridge.api.WTInfoW(WTI_DEFSYSCTX, 0, &context);
+  if (size == 0) {
+    SetLastErrorMessage(L"WTInfoW(WTI_DEFSYSCTX) failed");
+    return false;
+  }
+
+  context.lcOptions |= CXO_MESSAGES;
+  context.lcMsgBase = WT_DEFBASE;
+  context.lcPktData = PK_CONTEXT | PK_STATUS | PK_BUTTONS | PK_X | PK_Y | PK_NORMAL_PRESSURE;
+  context.lcPktMode = 0;
+  context.lcMoveMask = context.lcPktData;
+  context.lcBtnDnMask = 0xFFFFFFFFu;
+  context.lcBtnUpMask = 0xFFFFFFFFu;
+
+  AXIS pressureAxis{};
+  if (g_bridge.api.WTInfoW(WTI_DEVICES + context.lcDevice, DVC_NPRESSURE, &pressureAxis) != 0) {
+    g_bridge.pressureMin = pressureAxis.axMin;
+    g_bridge.pressureMax = pressureAxis.axMax;
+  } else {
+    g_bridge.pressureMin = 0;
+    g_bridge.pressureMax = 1023;
+  }
+
+  const HCTX hctx = g_bridge.api.WTOpenW(hwnd, &context, TRUE);
+  if (hctx == nullptr) {
+    SetLastErrorMessage(L"WTOpenW failed");
+    return false;
+  }
+
+  HookWindowTree(hwnd);
+  if (!g_bridge.hookedWindows.contains(hwnd)) {
+    g_bridge.api.WTClose(hctx);
+    SetLastErrorMessage(L"Failed to subclass the target window");
+    return false;
+  }
+
+  g_bridge.hwnd = hwnd;
+  g_bridge.context = hctx;
+  g_bridge.msgBase = context.lcMsgBase;
+  g_bridge.attached = true;
+  g_bridge.contactActive = false;
+  g_bridge.suppressPrimaryMouseUntil = 0;
+  g_bridge.lastPressure = 0.0;
+  g_bridge.lastButtons = 0;
+  g_bridge.queuedEvents.clear();
+
+  g_bridge.api.WTEnable(g_bridge.context, TRUE);
+  g_bridge.api.WTOverlap(g_bridge.context, TRUE);
+  SetLastErrorMessage(L"");
+  return true;
+}
+
+napi_value CreateBoolean(napi_env env, bool value) {
+  napi_value result;
+  napi_get_boolean(env, value, &result);
+  return result;
+}
+
+napi_value CreateInt32(napi_env env, int32_t value) {
+  napi_value result;
+  napi_create_int32(env, value, &result);
+  return result;
+}
+
+napi_value CreateDouble(napi_env env, double value) {
+  napi_value result;
+  napi_create_double(env, value, &result);
+  return result;
+}
+
+napi_value CreateString(napi_env env, const std::wstring &value) {
+  napi_value result;
+  napi_create_string_utf16(env, reinterpret_cast<const char16_t *>(value.c_str()), value.size(), &result);
+  return result;
+}
+
+napi_value IsSupported(napi_env env, napi_callback_info info) {
+  (void)info;
+  return CreateBoolean(env, EnsureWinTabLoaded());
+}
+
+napi_value Attach(napi_env env, napi_callback_info info) {
+  size_t argc = 1;
+  napi_value args[1];
+  napi_get_cb_info(env, info, &argc, args, nullptr, nullptr);
+
+  if (argc != 1) {
+    napi_throw_type_error(env, nullptr, "attach() expects a native window handle Buffer");
+    return nullptr;
+  }
+
+  bool isBuffer = false;
+  napi_is_buffer(env, args[0], &isBuffer);
+  if (!isBuffer) {
+    napi_throw_type_error(env, nullptr, "attach() expects a native window handle Buffer");
+    return nullptr;
+  }
+
+  void *data = nullptr;
+  size_t length = 0;
+  napi_get_buffer_info(env, args[0], &data, &length);
+  if (length < sizeof(void *)) {
+    napi_throw_type_error(env, nullptr, "Native window handle Buffer is too small");
+    return nullptr;
+  }
+
+  auto hwnd = *reinterpret_cast<HWND *>(data);
+  const bool attached = AttachInternal(hwnd);
+
+  napi_value result;
+  napi_create_object(env, &result);
+  napi_set_named_property(env, result, "attached", CreateBoolean(env, attached));
+  napi_set_named_property(env, result, "contactActive", CreateBoolean(env, g_bridge.contactActive));
+  napi_set_named_property(env, result, "pressureMin", CreateInt32(env, g_bridge.pressureMin));
+  napi_set_named_property(env, result, "pressureMax", CreateInt32(env, g_bridge.pressureMax));
+  napi_set_named_property(env, result, "lastError", CreateString(env, g_bridge.lastError));
+  return result;
+}
+
+napi_value Detach(napi_env env, napi_callback_info info) {
+  (void)info;
+  DetachInternal();
+  return nullptr;
+}
+
+napi_value DrainEvents(napi_env env, napi_callback_info info) {
+  (void)info;
+
+  napi_value result;
+  napi_create_array_with_length(env, g_bridge.queuedEvents.size(), &result);
+
+  uint32_t index = 0;
+  while (!g_bridge.queuedEvents.empty()) {
+    const auto event = g_bridge.queuedEvents.front();
+    g_bridge.queuedEvents.pop_front();
+
+    napi_value item;
+    napi_create_object(env, &item);
+
+    const char *kind = "move";
+    if (event.kind == PenEvent::Kind::Down) {
+      kind = "down";
+    } else if (event.kind == PenEvent::Kind::Up) {
+      kind = "up";
+    }
+
+    napi_value kindValue;
+    napi_create_string_utf8(env, kind, NAPI_AUTO_LENGTH, &kindValue);
+    napi_set_named_property(env, item, "kind", kindValue);
+    napi_set_named_property(env, item, "screenX", CreateInt32(env, event.screenX));
+    napi_set_named_property(env, item, "screenY", CreateInt32(env, event.screenY));
+    napi_set_named_property(env, item, "pressure", CreateDouble(env, event.pressure));
+    napi_set_named_property(env, item, "buttons", CreateInt32(env, static_cast<int32_t>(event.buttons)));
+    napi_set_element(env, result, index++, item);
+  }
+
+  return result;
+}
+
+napi_value GetStatus(napi_env env, napi_callback_info info) {
+  (void)info;
+  napi_value result;
+  napi_create_object(env, &result);
+  napi_set_named_property(env, result, "attached", CreateBoolean(env, g_bridge.attached));
+  napi_set_named_property(env, result, "contactActive", CreateBoolean(env, g_bridge.contactActive));
+  napi_set_named_property(env, result, "pressureMin", CreateInt32(env, g_bridge.pressureMin));
+  napi_set_named_property(env, result, "pressureMax", CreateInt32(env, g_bridge.pressureMax));
+  napi_set_named_property(env, result, "lastError", CreateString(env, g_bridge.lastError));
+  return result;
+}
+
+napi_value Init(napi_env env, napi_value exports) {
+  napi_property_descriptor descriptors[] = {
+      {"isSupported", nullptr, IsSupported, nullptr, nullptr, nullptr, napi_default, nullptr},
+      {"attach", nullptr, Attach, nullptr, nullptr, nullptr, napi_default, nullptr},
+      {"detach", nullptr, Detach, nullptr, nullptr, nullptr, napi_default, nullptr},
+      {"drainEvents", nullptr, DrainEvents, nullptr, nullptr, nullptr, napi_default, nullptr},
+      {"getStatus", nullptr, GetStatus, nullptr, nullptr, nullptr, napi_default, nullptr},
+  };
+
+  napi_define_properties(env, exports, sizeof(descriptors) / sizeof(descriptors[0]), descriptors);
+  return exports;
+}
+
+}  // namespace
+
+NAPI_MODULE(NODE_GYP_MODULE_NAME, Init)
+
+

--- a/native/wintab-pen-bridge/src/wintab_pen_bridge.cc
+++ b/native/wintab-pen-bridge/src/wintab_pen_bridge.cc
@@ -75,15 +75,29 @@ struct PacketData {
 };
 
 constexpr UINT WTI_INTERFACE = 1;
-constexpr UINT WTI_DEFCONTEXT = 3;
 constexpr UINT WTI_DEFSYSCTX = 4;
 constexpr UINT WTI_DEVICES = 100;
 constexpr UINT DVC_NPRESSURE = 15;
 
 constexpr UINT CXO_MESSAGES = 0x0004;
+constexpr UINT CXO_SYSTEM = 0x0001;
 
 constexpr UINT WT_DEFBASE = 0x7FF0;
 constexpr UINT WT_PACKET = 0;
+constexpr DWORD TIP_CONTACT_BUTTON_MASK = 0x1U;
+constexpr DWORD NON_TIP_BUTTON_MASK = ~TIP_CONTACT_BUTTON_MASK;
+
+// WinTab can report tiny non-zero hover pressure values. Use hysteresis so
+// pressure noise does not turn into synthetic pen clicks.
+constexpr double CONTACT_START_PRESSURE = 0.01;
+constexpr double CONTACT_END_PRESSURE = 0.005;
+constexpr double CONTACT_CONFIRM_PRESSURE = 0.03;
+constexpr ULONGLONG CONTACT_CONFIRMATION_MS = 12;
+constexpr uint32_t CONTACT_CONFIRMATION_PACKET_COUNT = 2;
+constexpr ULONGLONG RELEASE_CONFIRMATION_MS = 12;
+constexpr uint32_t RELEASE_CONFIRMATION_PACKET_COUNT = 2;
+constexpr ULONGLONG NON_TIP_BUTTON_PRESSURE_FREEZE_MS = 32;
+constexpr ULONGLONG NON_TIP_BUTTON_COORDINATE_STABILIZATION_MS = 48;
 
 constexpr WTPKT PK_CONTEXT = 0x0001;
 constexpr WTPKT PK_STATUS = 0x0002;
@@ -126,13 +140,43 @@ struct BridgeState {
   UINT msgBase = WT_DEFBASE;
   LONG pressureMin = 0;
   LONG pressureMax = 1023;
+  bool systemContextRelative = false;
+  LONG systemOrgX = 0;
+  LONG systemOrgY = 0;
+  LONG systemExtX = 0;
+  LONG systemExtY = 0;
+  bool packetAxisXResolved = false;
+  bool packetAxisYResolved = false;
+  bool packetFlipX = false;
+  bool packetFlipY = false;
+  LONG lastRawPacketX = 0;
+  LONG lastRawPacketY = 0;
+  LONG lastCursorCalibrationX = 0;
+  LONG lastCursorCalibrationY = 0;
+  bool hasLastCalibrationSample = false;
+  int packetAxisXScore = 0;
+  int packetAxisYScore = 0;
   bool attached = false;
   bool contactActive = false;
+  bool pendingContact = false;
+  bool pendingRelease = false;
   ULONGLONG suppressPrimaryMouseUntil = 0;
   LONG lastScreenX = 0;
   LONG lastScreenY = 0;
   double lastPressure = 0.0;
   DWORD lastButtons = 0;
+  DWORD lastRawButtons = 0;
+  ULONGLONG freezePressureUntil = 0;
+  ULONGLONG useCursorCoordinatesUntil = 0;
+  LONG pendingScreenX = 0;
+  LONG pendingScreenY = 0;
+  double pendingPressure = 0.0;
+  DWORD pendingButtons = 0;
+  ULONGLONG pendingSince = 0;
+  uint32_t pendingSampleCount = 0;
+  double pendingMaxPressure = 0.0;
+  ULONGLONG releaseSince = 0;
+  uint32_t releaseSampleCount = 0;
   std::wstring lastError;
   std::deque<PenEvent> queuedEvents;
   std::unordered_map<HWND, WNDPROC> hookedWindows;
@@ -180,6 +224,35 @@ double NormalizePressure(UINT pressure) {
   return std::clamp(normalized, 0.0, 1.0);
 }
 
+bool SampleChanged(LONG screenX, LONG screenY, double pressure, DWORD buttons) {
+  return screenX != g_bridge.lastScreenX || screenY != g_bridge.lastScreenY ||
+         std::fabs(pressure - g_bridge.lastPressure) > 0.0001 || buttons != g_bridge.lastButtons;
+}
+
+void UpdateLastSample(LONG screenX, LONG screenY, double pressure, DWORD buttons) {
+  g_bridge.lastScreenX = screenX;
+  g_bridge.lastScreenY = screenY;
+  g_bridge.lastPressure = pressure;
+  g_bridge.lastButtons = buttons;
+}
+
+void ClearPendingContact() {
+  g_bridge.pendingContact = false;
+  g_bridge.pendingScreenX = 0;
+  g_bridge.pendingScreenY = 0;
+  g_bridge.pendingPressure = 0.0;
+  g_bridge.pendingButtons = 0;
+  g_bridge.pendingSince = 0;
+  g_bridge.pendingSampleCount = 0;
+  g_bridge.pendingMaxPressure = 0.0;
+}
+
+void ClearPendingRelease() {
+  g_bridge.pendingRelease = false;
+  g_bridge.releaseSince = 0;
+  g_bridge.releaseSampleCount = 0;
+}
+
 void QueuePenEvent(PenEvent::Kind kind, LONG screenX, LONG screenY, double pressure, DWORD buttons) {
   g_bridge.queuedEvents.push_back(PenEvent{kind, screenX, screenY, pressure, buttons});
 }
@@ -190,6 +263,108 @@ POINT ResolveCursorScreenPoint(const PacketData &packet) {
     return point;
   }
   return point;
+}
+
+bool IsPlausibleScreenPoint(const POINT &point) {
+  const LONG left = GetSystemMetrics(SM_XVIRTUALSCREEN);
+  const LONG top = GetSystemMetrics(SM_YVIRTUALSCREEN);
+  const LONG right = left + GetSystemMetrics(SM_CXVIRTUALSCREEN);
+  const LONG bottom = top + GetSystemMetrics(SM_CYVIRTUALSCREEN);
+  constexpr LONG tolerance = 256;
+
+  return point.x >= left - tolerance && point.x <= right + tolerance && point.y >= top - tolerance &&
+         point.y <= bottom + tolerance;
+}
+
+LONG MirrorAxisInSystemSpace(const LONG value, const LONG origin, const LONG extent) {
+  const auto absoluteExtent = std::llabs(static_cast<long long>(extent));
+  if (absoluteExtent <= 0) {
+    return value;
+  }
+
+  return static_cast<LONG>(static_cast<long long>(origin) + absoluteExtent -
+                           (static_cast<long long>(value) - static_cast<long long>(origin)));
+}
+
+void UpdatePacketAxisCalibration(const PacketData &packet, const POINT &cursorPoint) {
+  if (g_bridge.systemContextRelative) {
+    return;
+  }
+
+  if (!g_bridge.hasLastCalibrationSample) {
+    g_bridge.lastRawPacketX = packet.pkX;
+    g_bridge.lastRawPacketY = packet.pkY;
+    g_bridge.lastCursorCalibrationX = cursorPoint.x;
+    g_bridge.lastCursorCalibrationY = cursorPoint.y;
+    g_bridge.hasLastCalibrationSample = true;
+    return;
+  }
+
+  const LONG packetDeltaX = packet.pkX - g_bridge.lastRawPacketX;
+  const LONG packetDeltaY = packet.pkY - g_bridge.lastRawPacketY;
+  const LONG cursorDeltaX = cursorPoint.x - g_bridge.lastCursorCalibrationX;
+  const LONG cursorDeltaY = cursorPoint.y - g_bridge.lastCursorCalibrationY;
+
+  constexpr LONG minimumDelta = 2;
+
+  if (!g_bridge.packetAxisXResolved && std::llabs(static_cast<long long>(packetDeltaX)) >= minimumDelta &&
+      std::llabs(static_cast<long long>(cursorDeltaX)) >= minimumDelta) {
+    g_bridge.packetAxisXScore += (packetDeltaX > 0) == (cursorDeltaX > 0) ? 1 : -1;
+    if (std::abs(g_bridge.packetAxisXScore) >= 3) {
+      g_bridge.packetAxisXResolved = true;
+      g_bridge.packetFlipX = g_bridge.packetAxisXScore < 0;
+    }
+  }
+
+  if (!g_bridge.packetAxisYResolved && std::llabs(static_cast<long long>(packetDeltaY)) >= minimumDelta &&
+      std::llabs(static_cast<long long>(cursorDeltaY)) >= minimumDelta) {
+    g_bridge.packetAxisYScore += (packetDeltaY > 0) == (cursorDeltaY > 0) ? 1 : -1;
+    if (std::abs(g_bridge.packetAxisYScore) >= 3) {
+      g_bridge.packetAxisYResolved = true;
+      g_bridge.packetFlipY = g_bridge.packetAxisYScore < 0;
+    }
+  }
+
+  g_bridge.lastRawPacketX = packet.pkX;
+  g_bridge.lastRawPacketY = packet.pkY;
+  g_bridge.lastCursorCalibrationX = cursorPoint.x;
+  g_bridge.lastCursorCalibrationY = cursorPoint.y;
+}
+
+POINT ResolvePacketScreenPoint(const PacketData &packet) {
+  const POINT cursorPoint = ResolveCursorScreenPoint(packet);
+  const auto now = GetTickCount64();
+
+  if (now <= g_bridge.useCursorCoordinatesUntil) {
+    g_bridge.lastRawPacketX = packet.pkX;
+    g_bridge.lastRawPacketY = packet.pkY;
+    g_bridge.lastCursorCalibrationX = cursorPoint.x;
+    g_bridge.lastCursorCalibrationY = cursorPoint.y;
+    g_bridge.hasLastCalibrationSample = true;
+    return cursorPoint;
+  }
+
+  UpdatePacketAxisCalibration(packet, cursorPoint);
+
+  if (g_bridge.systemContextRelative) {
+    return cursorPoint;
+  }
+
+  POINT point{packet.pkX, packet.pkY};
+
+  if (g_bridge.packetAxisXResolved && g_bridge.packetFlipX) {
+    point.x = MirrorAxisInSystemSpace(point.x, g_bridge.systemOrgX, g_bridge.systemExtX);
+  }
+
+  if (g_bridge.packetAxisYResolved && g_bridge.packetFlipY) {
+    point.y = MirrorAxisInSystemSpace(point.y, g_bridge.systemOrgY, g_bridge.systemExtY);
+  }
+
+  if (IsPlausibleScreenPoint(point)) {
+    return point;
+  }
+
+  return cursorPoint;
 }
 
 bool IsPointerMessage(const UINT message) {
@@ -224,7 +399,7 @@ bool ShouldSuppressPenPointerMessage(const UINT message, const WPARAM wParam) {
 }
 
 bool ShouldSuppressPrimaryMousePathNow() {
-  return g_bridge.contactActive || GetTickCount64() <= g_bridge.suppressPrimaryMouseUntil;
+  return g_bridge.contactActive || g_bridge.pendingContact || GetTickCount64() <= g_bridge.suppressPrimaryMouseUntil;
 }
 
 bool ShouldSuppressPrimaryMouseMessage(const UINT message) {
@@ -256,43 +431,109 @@ void ProcessQueuedPackets() {
 }
 
 void ProcessPacket(const PacketData &packet) {
-  const auto pressure = NormalizePressure(packet.pkNormalPressure);
-  const bool contact = pressure > 0.0 || (packet.pkButtons & 0x1U) != 0;
-  const POINT cursorPoint = ResolveCursorScreenPoint(packet);
+  const DWORD rawButtons = packet.pkButtons;
+  const DWORD penButtons = rawButtons & TIP_CONTACT_BUTTON_MASK;
+  const bool nonTipButtonStateChanged = ((rawButtons ^ g_bridge.lastRawButtons) & NON_TIP_BUTTON_MASK) != 0;
+  const auto now = GetTickCount64();
+  auto pressure = NormalizePressure(packet.pkNormalPressure);
+  const bool tipContact = (penButtons & TIP_CONTACT_BUTTON_MASK) != 0;
+  if (g_bridge.contactActive && nonTipButtonStateChanged) {
+    g_bridge.freezePressureUntil = now + NON_TIP_BUTTON_PRESSURE_FREEZE_MS;
+  }
+  if (nonTipButtonStateChanged || (rawButtons & NON_TIP_BUTTON_MASK) != 0) {
+    g_bridge.useCursorCoordinatesUntil = now + NON_TIP_BUTTON_COORDINATE_STABILIZATION_MS;
+    g_bridge.hasLastCalibrationSample = false;
+  }
+  if (g_bridge.contactActive && now <= g_bridge.freezePressureUntil) {
+    pressure = g_bridge.lastPressure;
+  }
+  const bool pressureContact =
+      g_bridge.contactActive ? pressure > CONTACT_END_PRESSURE : pressure >= CONTACT_START_PRESSURE;
+  const bool contact = tipContact || pressureContact;
+  const POINT cursorPoint = ResolvePacketScreenPoint(packet);
+  g_bridge.lastRawButtons = rawButtons;
 
-  if (!g_bridge.contactActive && contact) {
+  if (!g_bridge.contactActive && !g_bridge.pendingContact && contact) {
+    g_bridge.pendingContact = true;
+    g_bridge.pendingSince = now;
+    g_bridge.pendingScreenX = cursorPoint.x;
+    g_bridge.pendingScreenY = cursorPoint.y;
+    g_bridge.pendingPressure = pressure;
+    g_bridge.pendingButtons = penButtons;
+    g_bridge.pendingSampleCount = 1;
+    g_bridge.pendingMaxPressure = pressure;
+    return;
+  }
+
+  if (!g_bridge.contactActive && g_bridge.pendingContact) {
+    if (!contact) {
+      ClearPendingContact();
+      return;
+    }
+
+    g_bridge.pendingScreenX = cursorPoint.x;
+    g_bridge.pendingScreenY = cursorPoint.y;
+    g_bridge.pendingPressure = pressure;
+    g_bridge.pendingButtons = penButtons;
+    g_bridge.pendingSampleCount += 1;
+    g_bridge.pendingMaxPressure = std::max(g_bridge.pendingMaxPressure, pressure);
+
+    const bool confirmedByTip = tipContact;
+    const bool confirmedByPressure = g_bridge.pendingSampleCount >= CONTACT_CONFIRMATION_PACKET_COUNT &&
+                                     g_bridge.pendingMaxPressure >= CONTACT_CONFIRM_PRESSURE &&
+                                     now - g_bridge.pendingSince >= CONTACT_CONFIRMATION_MS;
+    const bool confirmed = confirmedByTip || confirmedByPressure;
+    if (!confirmed) {
+      return;
+    }
+
     g_bridge.contactActive = true;
+    g_bridge.pendingContact = false;
     g_bridge.suppressPrimaryMouseUntil = 0;
-    g_bridge.lastScreenX = cursorPoint.x;
-    g_bridge.lastScreenY = cursorPoint.y;
-    g_bridge.lastPressure = pressure;
-    g_bridge.lastButtons = packet.pkButtons;
-    QueuePenEvent(PenEvent::Kind::Down, cursorPoint.x, cursorPoint.y, pressure, packet.pkButtons);
+    UpdateLastSample(
+        g_bridge.pendingScreenX, g_bridge.pendingScreenY, g_bridge.pendingPressure, g_bridge.pendingButtons);
+    QueuePenEvent(
+        PenEvent::Kind::Down, g_bridge.pendingScreenX, g_bridge.pendingScreenY, g_bridge.pendingPressure,
+        g_bridge.pendingButtons);
+    ClearPendingContact();
+
+    if (SampleChanged(cursorPoint.x, cursorPoint.y, pressure, penButtons)) {
+      UpdateLastSample(cursorPoint.x, cursorPoint.y, pressure, penButtons);
+      QueuePenEvent(PenEvent::Kind::Move, cursorPoint.x, cursorPoint.y, pressure, penButtons);
+    }
     return;
   }
 
   if (g_bridge.contactActive && contact) {
-    const bool changed = cursorPoint.x != g_bridge.lastScreenX || cursorPoint.y != g_bridge.lastScreenY ||
-                         std::fabs(pressure - g_bridge.lastPressure) > 0.0001 ||
-                         packet.pkButtons != g_bridge.lastButtons;
-    g_bridge.lastScreenX = cursorPoint.x;
-    g_bridge.lastScreenY = cursorPoint.y;
-    g_bridge.lastPressure = pressure;
-    g_bridge.lastButtons = packet.pkButtons;
-    if (changed) {
-      QueuePenEvent(PenEvent::Kind::Move, cursorPoint.x, cursorPoint.y, pressure, packet.pkButtons);
+    ClearPendingRelease();
+    if (SampleChanged(cursorPoint.x, cursorPoint.y, pressure, penButtons)) {
+      UpdateLastSample(cursorPoint.x, cursorPoint.y, pressure, penButtons);
+      QueuePenEvent(PenEvent::Kind::Move, cursorPoint.x, cursorPoint.y, pressure, penButtons);
     }
     return;
   }
 
   if (g_bridge.contactActive && !contact) {
+    if (!g_bridge.pendingRelease) {
+      g_bridge.pendingRelease = true;
+      g_bridge.releaseSince = now;
+      g_bridge.releaseSampleCount = 1;
+      return;
+    }
+
+    g_bridge.releaseSampleCount += 1;
+    const bool confirmed =
+        now - g_bridge.releaseSince >= RELEASE_CONFIRMATION_MS ||
+        g_bridge.releaseSampleCount >= RELEASE_CONFIRMATION_PACKET_COUNT;
+    if (!confirmed) {
+      return;
+    }
+
     g_bridge.contactActive = false;
+    ClearPendingRelease();
     g_bridge.suppressPrimaryMouseUntil = GetTickCount64() + 200;
-    g_bridge.lastScreenX = cursorPoint.x;
-    g_bridge.lastScreenY = cursorPoint.y;
-    g_bridge.lastPressure = 0.0;
-    g_bridge.lastButtons = packet.pkButtons;
-    QueuePenEvent(PenEvent::Kind::Up, cursorPoint.x, cursorPoint.y, 0.0, packet.pkButtons);
+    UpdateLastSample(cursorPoint.x, cursorPoint.y, 0.0, penButtons);
+    QueuePenEvent(PenEvent::Kind::Up, cursorPoint.x, cursorPoint.y, 0.0, penButtons);
   }
 }
 
@@ -323,7 +564,7 @@ LRESULT CallOriginalWindowProc(HWND hwnd, UINT message, WPARAM wParam, LPARAM lP
 
 LRESULT CALLBACK HookWndProc(HWND hwnd, UINT message, WPARAM wParam, LPARAM lParam) {
   if (g_bridge.attached) {
-    if (message == g_bridge.msgBase + WT_PACKET) {
+    if (message == g_bridge.msgBase + WT_PACKET || IsPointerMessage(message) || ShouldSuppressPrimaryMouseMessage(message)) {
       ProcessQueuedPackets();
     }
 
@@ -386,9 +627,21 @@ void DetachInternal() {
   g_bridge.hwnd = nullptr;
   g_bridge.attached = false;
   g_bridge.contactActive = false;
+  ClearPendingContact();
+  ClearPendingRelease();
   g_bridge.suppressPrimaryMouseUntil = 0;
   g_bridge.lastPressure = 0.0;
   g_bridge.lastButtons = 0;
+  g_bridge.lastRawButtons = 0;
+  g_bridge.freezePressureUntil = 0;
+  g_bridge.useCursorCoordinatesUntil = 0;
+  g_bridge.packetAxisXResolved = false;
+  g_bridge.packetAxisYResolved = false;
+  g_bridge.packetFlipX = false;
+  g_bridge.packetFlipY = false;
+  g_bridge.hasLastCalibrationSample = false;
+  g_bridge.packetAxisXScore = 0;
+  g_bridge.packetAxisYScore = 0;
   g_bridge.queuedEvents.clear();
 }
 
@@ -413,7 +666,8 @@ bool AttachInternal(HWND hwnd) {
     return false;
   }
 
-  context.lcOptions |= CXO_MESSAGES;
+  context.lcOptions |= CXO_SYSTEM | CXO_MESSAGES;
+  context.lcSysMode = FALSE;
   context.lcMsgBase = WT_DEFBASE;
   context.lcPktData = PK_CONTEXT | PK_STATUS | PK_BUTTONS | PK_X | PK_Y | PK_NORMAL_PRESSURE;
   context.lcPktMode = 0;
@@ -446,11 +700,28 @@ bool AttachInternal(HWND hwnd) {
   g_bridge.hwnd = hwnd;
   g_bridge.context = hctx;
   g_bridge.msgBase = context.lcMsgBase;
+  g_bridge.systemContextRelative = context.lcSysMode != FALSE;
+  g_bridge.systemOrgX = context.lcSysOrgX;
+  g_bridge.systemOrgY = context.lcSysOrgY;
+  g_bridge.systemExtX = context.lcSysExtX;
+  g_bridge.systemExtY = context.lcSysExtY;
+  g_bridge.packetAxisXResolved = false;
+  g_bridge.packetAxisYResolved = false;
+  g_bridge.packetFlipX = false;
+  g_bridge.packetFlipY = false;
+  g_bridge.hasLastCalibrationSample = false;
+  g_bridge.packetAxisXScore = 0;
+  g_bridge.packetAxisYScore = 0;
   g_bridge.attached = true;
   g_bridge.contactActive = false;
+  ClearPendingContact();
+  ClearPendingRelease();
   g_bridge.suppressPrimaryMouseUntil = 0;
   g_bridge.lastPressure = 0.0;
   g_bridge.lastButtons = 0;
+  g_bridge.lastRawButtons = 0;
+  g_bridge.freezePressureUntil = 0;
+  g_bridge.useCursorCoordinatesUntil = 0;
   g_bridge.queuedEvents.clear();
 
   g_bridge.api.WTEnable(g_bridge.context, TRUE);

--- a/native/wintab-pen-bridge/src/wintab_pen_bridge.cc
+++ b/native/wintab-pen-bridge/src/wintab_pen_bridge.cc
@@ -98,6 +98,7 @@ constexpr ULONGLONG RELEASE_CONFIRMATION_MS = 12;
 constexpr uint32_t RELEASE_CONFIRMATION_PACKET_COUNT = 2;
 constexpr ULONGLONG NON_TIP_BUTTON_PRESSURE_FREEZE_MS = 32;
 constexpr ULONGLONG NON_TIP_BUTTON_COORDINATE_STABILIZATION_MS = 48;
+constexpr size_t MAX_QUEUED_EVENTS = 256;
 
 constexpr WTPKT PK_CONTEXT = 0x0001;
 constexpr WTPKT PK_STATUS = 0x0002;
@@ -254,6 +255,25 @@ void ClearPendingRelease() {
 }
 
 void QueuePenEvent(PenEvent::Kind kind, LONG screenX, LONG screenY, double pressure, DWORD buttons) {
+  if (kind == PenEvent::Kind::Move && !g_bridge.queuedEvents.empty() &&
+      g_bridge.queuedEvents.back().kind == PenEvent::Kind::Move) {
+    g_bridge.queuedEvents.back() = PenEvent{kind, screenX, screenY, pressure, buttons};
+    return;
+  }
+
+  if (g_bridge.queuedEvents.size() >= MAX_QUEUED_EVENTS) {
+    const auto oldestMove =
+        std::find_if(g_bridge.queuedEvents.begin(), g_bridge.queuedEvents.end(), [](const PenEvent &event) {
+          return event.kind == PenEvent::Kind::Move;
+        });
+
+    if (oldestMove != g_bridge.queuedEvents.end()) {
+      g_bridge.queuedEvents.erase(oldestMove);
+    } else if (kind == PenEvent::Kind::Move) {
+      return;
+    }
+  }
+
   g_bridge.queuedEvents.push_back(PenEvent{kind, screenX, screenY, pressure, buttons});
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,9 @@
         "@eslint/compat": "^1.3.1",
         "node-pty": "^1.1.0-beta27"
       },
+      "optionalDependencies": {
+        "wintab-pen-bridge": "file:./native/wintab-pen-bridge"
+      },
       "devDependencies": {
         "@electron-toolkit/preload": "^3.0.2",
         "@electron-toolkit/typed-ipc": "^1.0.2",
@@ -96,6 +99,14 @@
       "peerDependencies": {
         "@emotion/react": "^11.13.5"
       }
+    },
+    "native/wintab-pen-bridge": {
+      "version": "0.0.1",
+      "hasInstallScript": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ]
     },
     "node_modules/@ampproject/remapping": {
       "version": "2.3.0",
@@ -16114,6 +16125,11 @@
       "engines": {
         "node": ">=4"
       }
+    },
+    "node_modules/wintab-pen-bridge": {
+      "optional": true,
+      "resolved": "native/wintab-pen-bridge",
+      "link": true
     },
     "node_modules/word-wrap": {
       "version": "1.2.5",

--- a/package-lock.json
+++ b/package-lock.json
@@ -108,6 +108,7 @@
       "os": [
         "win32"
       ]
+    },
     "node_modules/@actions/core": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/@actions/core/-/core-2.0.3.tgz",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "test": "npm rebuild node-pty && vitest",
     "test:ui": "npm rebuild node-pty && vitest --coverage --ui",
     "test:no-watch": "npm rebuild node-pty && vitest --no-watch",
-    "rebuild": "node -e \"const { spawnSync } = require('node:child_process'); const modules = process.platform === 'win32' ? 'node-pty,wintab-pen-bridge' : 'node-pty'; const command = process.platform === 'win32' ? 'npx.cmd' : 'npx'; const result = spawnSync(command, ['electron-rebuild', '-f', '-w', modules], { stdio: 'inherit' }); process.exit(result.status ?? 1);\"",
+    "rebuild": "node -e \"const { spawnSync } = require('node:child_process'); const path = require('node:path'); const modules = process.platform === 'win32' ? 'node-pty,wintab-pen-bridge' : 'node-pty'; const command = path.resolve('node_modules', '.bin', process.platform === 'win32' ? 'electron-rebuild.cmd' : 'electron-rebuild'); const result = process.platform === 'win32' ? spawnSync(command, ['-f', '-w', modules], { stdio: 'inherit', shell: true }) : spawnSync(command, ['-f', '-w', modules], { stdio: 'inherit' }); if (result.error) { console.error(result.error); process.exit(1); } process.exit(result.status ?? 1);\"",
     "postinstall": "npm run rebuild",
     "react-devtools": "react-devtools",
     "version": "npm version --message 'chore: bump version to v%s'"

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "test": "npm rebuild node-pty && vitest",
     "test:ui": "npm rebuild node-pty && vitest --coverage --ui",
     "test:no-watch": "npm rebuild node-pty && vitest --no-watch",
-    "rebuild": "electron-rebuild -f -w node-pty",
+    "rebuild": "node -e \"const { spawnSync } = require('node:child_process'); const modules = process.platform === 'win32' ? 'node-pty,wintab-pen-bridge' : 'node-pty'; const command = process.platform === 'win32' ? 'npx.cmd' : 'npx'; const result = spawnSync(command, ['electron-rebuild', '-f', '-w', modules], { stdio: 'inherit' }); process.exit(result.status ?? 1);\"",
     "postinstall": "npm run rebuild",
     "react-devtools": "react-devtools",
     "version": "npm version --message 'chore: bump version to v%s'"
@@ -122,6 +122,9 @@
   "dependencies": {
     "@eslint/compat": "^1.3.1",
     "node-pty": "^1.1.0-beta27"
+  },
+  "optionalDependencies": {
+    "wintab-pen-bridge": "file:./native/wintab-pen-bridge"
   },
   "uv": {
     "linux": {

--- a/src/main/invoke-manager.ts
+++ b/src/main/invoke-manager.ts
@@ -4,7 +4,7 @@ import { BrowserWindow, ipcMain, shell } from 'electron';
 import type Store from 'electron-store';
 import fs from 'fs/promises';
 import ip from 'ip';
-import { join } from 'path';
+import path, { join } from 'path';
 import { shellEnvSync } from 'shell-env';
 
 import { CommandRunner } from '@/lib/command-runner';
@@ -23,6 +23,7 @@ import type {
 } from '@/shared/types';
 
 import type { InstallManager } from './install-manager';
+import { InvokeWindowWinTabBridge } from './invoke-window-wintab-bridge';
 
 export class InvokeManager {
   private status: WithTimestamp<InvokeProcessStatus>;
@@ -37,6 +38,7 @@ export class InvokeManager {
   private commandRunner: CommandRunner;
   private cols: number | undefined;
   private rows: number | undefined;
+  private windowWinTabBridge: InvokeWindowWinTabBridge | null;
 
   constructor(arg: {
     store: Store<StoreData>;
@@ -60,6 +62,7 @@ export class InvokeManager {
     this.commandRunner = new CommandRunner();
     this.cols = undefined;
     this.rows = undefined;
+    this.windowWinTabBridge = null;
   }
 
   getStatus = (): WithTimestamp<InvokeProcessStatus> => {
@@ -228,11 +231,15 @@ export class InvokeManager {
       minHeight: 600,
       webPreferences: {
         devTools: true,
+        preload: path.join(__dirname, '../preload/index.js'),
+        contextIsolation: true,
+        nodeIntegration: false,
         backgroundThrottling: false, // Prevent memory spikes from throttling when window loses focus
         additionalArguments: [
           '--enable-gpu-rasterization', // Offload canvas to GPU
           '--enable-zero-copy', // Reduce memory copies
           '--enable-accelerated-2d-canvas', // GPU acceleration for 2D canvas
+          '--invoke-hosted-window',
         ],
       },
       autoHideMenuBar: true,
@@ -242,6 +249,7 @@ export class InvokeManager {
     });
 
     this.window = window;
+    this.windowWinTabBridge = new InvokeWindowWinTabBridge(window, this.log);
 
     const winProps = this.store.get('appWindowProps');
     manageWindowSize(
@@ -259,6 +267,8 @@ export class InvokeManager {
     });
 
     window.on('close', () => {
+      this.windowWinTabBridge?.detach();
+      this.windowWinTabBridge = null;
       this.exitInvoke();
     });
 
@@ -291,6 +301,8 @@ export class InvokeManager {
 
       // Close the crashed window (it may still be visible but unresponsive)
       if (this.window && !this.window.isDestroyed()) {
+        this.windowWinTabBridge?.detach();
+        this.windowWinTabBridge = null;
         this.window.destroy();
       }
 
@@ -308,6 +320,12 @@ export class InvokeManager {
         const duration = Date.now() - unresponsiveTimestamp;
         this.log.info(c.yellow(`UI Window is responsive again (was unresponsive for ${duration}ms)\r\n`));
         unresponsiveTimestamp = null;
+      }
+    });
+
+    window.webContents.on('before-mouse-event', (event, mouse) => {
+      if (this.windowWinTabBridge?.shouldSuppressPrimaryMouse(mouse)) {
+        event.preventDefault();
       }
     });
 
@@ -331,6 +349,9 @@ export class InvokeManager {
     });
 
     const localUrl = url.replace('0.0.0.0', '127.0.0.1');
+    window.webContents.on('did-finish-load', () => {
+      this.windowWinTabBridge?.attach();
+    });
     window.webContents.loadURL(localUrl);
   };
 
@@ -373,6 +394,8 @@ export class InvokeManager {
       return;
     }
     if (!this.window.isDestroyed()) {
+      this.windowWinTabBridge?.detach();
+      this.windowWinTabBridge = null;
       this.window.destroy();
     }
     this.window = null;

--- a/src/main/invoke-window-wintab-bridge.ts
+++ b/src/main/invoke-window-wintab-bridge.ts
@@ -1,0 +1,200 @@
+import type { BrowserWindow, MouseInputEvent } from 'electron';
+import { screen } from 'electron';
+
+import type { SimpleLogger } from '@/lib/simple-logger';
+
+type NativeAttachResult = {
+  attached: boolean;
+  contactActive: boolean;
+  pressureMin: number;
+  pressureMax: number;
+  lastError: string;
+};
+
+type NativePenEvent = {
+  kind: 'down' | 'move' | 'up';
+  screenX: number;
+  screenY: number;
+  pressure: number;
+  buttons: number;
+};
+
+type NativeAddon = {
+  isSupported: () => boolean;
+  attach: (hwndBuffer: Buffer) => NativeAttachResult;
+  detach: () => void;
+  drainEvents: () => NativePenEvent[];
+  getStatus: () => NativeAttachResult;
+};
+
+type BridgedPenEvent = NativePenEvent & {
+  clientX: number;
+  clientY: number;
+};
+
+const IPC_STATUS_CHANNEL = 'invoke-window:wintab-status';
+const IPC_EVENT_CHANNEL = 'invoke-window:wintab-pen-event';
+const SUPPRESS_PRIMARY_MOUSE_GRACE_MS = 200;
+
+export class InvokeWindowWinTabBridge {
+  private readonly window: BrowserWindow;
+  private readonly log: SimpleLogger;
+  private addon: NativeAddon | null = null;
+  private pollTimer: NodeJS.Timeout | null = null;
+  private attached = false;
+  private penContactActive = false;
+  private suppressPrimaryMouseUntil = 0;
+  private lastPenActivityAt = 0;
+
+  constructor(window: BrowserWindow, log: SimpleLogger) {
+    this.window = window;
+    this.log = log;
+  }
+
+  attach = (): void => {
+    if (process.platform !== 'win32') {
+      this.sendStatus(false, 'WinTab bridge is only available on Windows');
+      return;
+    }
+
+    const addon = this.loadAddon();
+    if (!addon) {
+      this.sendStatus(false, 'Failed to load WinTab bridge native addon');
+      return;
+    }
+
+    if (!addon.isSupported()) {
+      const status = addon.getStatus();
+      this.sendStatus(false, status.lastError || 'WinTab is not supported by the current driver');
+      return;
+    }
+
+    const result = addon.attach(this.window.getNativeWindowHandle());
+    if (!result.attached) {
+      this.sendStatus(false, result.lastError || 'Failed to attach WinTab bridge');
+      return;
+    }
+
+    this.addon = addon;
+    this.attached = true;
+    this.penContactActive = result.contactActive;
+    this.lastPenActivityAt = Date.now();
+    this.sendStatus(true, 'WinTab attached');
+
+    this.pollTimer = setInterval(this.drainAndForwardEvents, 1);
+  };
+
+  detach = (): void => {
+    if (this.pollTimer) {
+      clearInterval(this.pollTimer);
+      this.pollTimer = null;
+    }
+
+    if (this.addon && this.attached) {
+      this.addon.detach();
+    }
+
+    this.attached = false;
+    this.addon = null;
+    this.penContactActive = false;
+    this.suppressPrimaryMouseUntil = 0;
+    this.lastPenActivityAt = 0;
+  };
+
+  shouldSuppressPrimaryMouse = (mouse: MouseInputEvent): boolean => {
+    if (!this.attached || !this.addon) {
+      return false;
+    }
+
+    if (mouse.button && mouse.button !== 'left') {
+      return false;
+    }
+
+    if (mouse.type === 'contextMenu' || mouse.type === 'mouseWheel') {
+      return false;
+    }
+
+    const status = this.addon.getStatus();
+    const now = Date.now();
+
+    if (status.contactActive) {
+      this.penContactActive = true;
+      this.lastPenActivityAt = now;
+    }
+
+    if (!this.penContactActive && now > this.suppressPrimaryMouseUntil) {
+      return false;
+    }
+
+    if (!status.contactActive && now > this.suppressPrimaryMouseUntil && now - this.lastPenActivityAt > SUPPRESS_PRIMARY_MOUSE_GRACE_MS) {
+      this.penContactActive = false;
+      return false;
+    }
+
+    return true;
+  };
+
+  private loadAddon = (): NativeAddon | null => {
+    if (this.addon) {
+      return this.addon;
+    }
+
+    try {
+      const addon = require('wintab-pen-bridge') as NativeAddon;
+      this.addon = addon;
+      return addon;
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      this.log.warn(`Failed to require wintab-pen-bridge: ${message}\r\n`);
+      return null;
+    }
+  };
+
+  private sendStatus = (enabled: boolean, message: string): void => {
+    if (this.window.isDestroyed()) {
+      return;
+    }
+    this.window.webContents.send(IPC_STATUS_CHANNEL, { enabled, message });
+  };
+
+  private drainAndForwardEvents = (): void => {
+    if (!this.window || this.window.isDestroyed() || !this.addon) {
+      return;
+    }
+
+    const events = this.addon.drainEvents();
+    if (events.length === 0) {
+      return;
+    }
+
+    const now = Date.now();
+    const contentBounds = this.window.getContentBounds();
+    for (const event of events) {
+      this.lastPenActivityAt = now;
+      if (event.kind === 'down') {
+        this.penContactActive = true;
+      } else if (event.kind === 'up') {
+        this.penContactActive = false;
+        this.suppressPrimaryMouseUntil = now + SUPPRESS_PRIMARY_MOUSE_GRACE_MS;
+      }
+
+      const dipPoint = screen.screenToDipPoint({ x: event.screenX, y: event.screenY });
+      const clientX = dipPoint.x - contentBounds.x;
+      const clientY = dipPoint.y - contentBounds.y;
+
+      if (clientX < 0 || clientY < 0 || clientX > contentBounds.width || clientY > contentBounds.height) {
+        continue;
+      }
+
+      const bridgedEvent: BridgedPenEvent = {
+        ...event,
+        screenX: dipPoint.x,
+        screenY: dipPoint.y,
+        clientX,
+        clientY,
+      };
+
+      this.window.webContents.send(IPC_EVENT_CHANNEL, bridgedEvent);
+    }
+  };
+}

--- a/src/main/invoke-window-wintab-bridge.ts
+++ b/src/main/invoke-window-wintab-bridge.ts
@@ -126,7 +126,11 @@ export class InvokeWindowWinTabBridge {
       return false;
     }
 
-    if (!status.contactActive && now > this.suppressPrimaryMouseUntil && now - this.lastPenActivityAt > SUPPRESS_PRIMARY_MOUSE_GRACE_MS) {
+    if (
+      !status.contactActive &&
+      now > this.suppressPrimaryMouseUntil &&
+      now - this.lastPenActivityAt > SUPPRESS_PRIMARY_MOUSE_GRACE_MS
+    ) {
       this.penContactActive = false;
       return false;
     }

--- a/src/main/invoke-window-wintab-bridge.ts
+++ b/src/main/invoke-window-wintab-bridge.ts
@@ -1,5 +1,5 @@
-import type { BrowserWindow, MouseInputEvent } from 'electron';
-import { screen } from 'electron';
+import type { BrowserWindow, IpcMainEvent, MouseInputEvent } from 'electron';
+import { ipcMain, screen } from 'electron';
 
 import type { SimpleLogger } from '@/lib/simple-logger';
 
@@ -34,7 +34,9 @@ type BridgedPenEvent = NativePenEvent & {
 
 const IPC_STATUS_CHANNEL = 'invoke-window:wintab-status';
 const IPC_EVENT_CHANNEL = 'invoke-window:wintab-pen-event';
+const IPC_ACK_CHANNEL = 'invoke-window:wintab-pen-event-ack';
 const SUPPRESS_PRIMARY_MOUSE_GRACE_MS = 200;
+const EVENT_POLL_INTERVAL_MS = 8;
 
 export class InvokeWindowWinTabBridge {
   private readonly window: BrowserWindow;
@@ -45,6 +47,8 @@ export class InvokeWindowWinTabBridge {
   private penContactActive = false;
   private suppressPrimaryMouseUntil = 0;
   private lastPenActivityAt = 0;
+  private batchInFlight = false;
+  private ackListenerInstalled = false;
 
   constructor(window: BrowserWindow, log: SimpleLogger) {
     this.window = window;
@@ -52,6 +56,10 @@ export class InvokeWindowWinTabBridge {
   }
 
   attach = (): void => {
+    if (this.attached || this.pollTimer || this.ackListenerInstalled) {
+      this.detach();
+    }
+
     if (process.platform !== 'win32') {
       this.sendStatus(false, 'WinTab bridge is only available on Windows');
       return;
@@ -79,9 +87,12 @@ export class InvokeWindowWinTabBridge {
     this.attached = true;
     this.penContactActive = result.contactActive;
     this.lastPenActivityAt = Date.now();
+    this.batchInFlight = false;
+    ipcMain.on(IPC_ACK_CHANNEL, this.handleBatchAck);
+    this.ackListenerInstalled = true;
     this.sendStatus(true, 'WinTab attached');
 
-    this.pollTimer = setInterval(this.drainAndForwardEvents, 1);
+    this.pollTimer = setInterval(this.drainAndForwardEvents, EVENT_POLL_INTERVAL_MS);
   };
 
   detach = (): void => {
@@ -94,11 +105,17 @@ export class InvokeWindowWinTabBridge {
       this.addon.detach();
     }
 
+    if (this.ackListenerInstalled) {
+      ipcMain.removeListener(IPC_ACK_CHANNEL, this.handleBatchAck);
+      this.ackListenerInstalled = false;
+    }
+
     this.attached = false;
     this.addon = null;
     this.penContactActive = false;
     this.suppressPrimaryMouseUntil = 0;
     this.lastPenActivityAt = 0;
+    this.batchInFlight = false;
   };
 
   shouldSuppressPrimaryMouse = (mouse: MouseInputEvent): boolean => {
@@ -161,8 +178,16 @@ export class InvokeWindowWinTabBridge {
     this.window.webContents.send(IPC_STATUS_CHANNEL, { enabled, message });
   };
 
+  private handleBatchAck = (event: IpcMainEvent): void => {
+    if (event.sender !== this.window.webContents) {
+      return;
+    }
+
+    this.batchInFlight = false;
+  };
+
   private drainAndForwardEvents = (): void => {
-    if (!this.window || this.window.isDestroyed() || !this.addon) {
+    if (!this.window || this.window.isDestroyed() || !this.addon || this.batchInFlight) {
       return;
     }
 
@@ -173,6 +198,7 @@ export class InvokeWindowWinTabBridge {
 
     const now = Date.now();
     const contentBounds = this.window.getContentBounds();
+    const bridgedEvents: BridgedPenEvent[] = [];
     for (const event of events) {
       this.lastPenActivityAt = now;
       if (event.kind === 'down') {
@@ -186,19 +212,25 @@ export class InvokeWindowWinTabBridge {
       const clientX = dipPoint.x - contentBounds.x;
       const clientY = dipPoint.y - contentBounds.y;
 
-      if (clientX < 0 || clientY < 0 || clientX > contentBounds.width || clientY > contentBounds.height) {
+      if (
+        event.kind !== 'up' &&
+        (clientX < 0 || clientY < 0 || clientX > contentBounds.width || clientY > contentBounds.height)
+      ) {
         continue;
       }
 
-      const bridgedEvent: BridgedPenEvent = {
+      bridgedEvents.push({
         ...event,
         screenX: dipPoint.x,
         screenY: dipPoint.y,
         clientX,
         clientY,
-      };
+      });
+    }
 
-      this.window.webContents.send(IPC_EVENT_CHANNEL, bridgedEvent);
+    if (bridgedEvents.length > 0) {
+      this.batchInFlight = true;
+      this.window.webContents.send(IPC_EVENT_CHANNEL, bridgedEvents);
     }
   };
 }

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -31,10 +31,13 @@ if (IS_INVOKE_HOSTED_WINDOW) {
 function setupInvokeWindowWinTabBridge() {
   let bridgeEnabled = false;
   let suppressionInstalled = false;
+  let mouseTrackingInstalled = false;
   let syntheticPenSessionActive = false;
+  let syntheticMouseSessionActive = false;
   let suppressPrimaryMouseUntil = 0;
   let activeTarget: EventTarget | null = null;
   let dispatchingSyntheticMouseEvent = false;
+  let activeAuxMouseButtons = 0;
 
   const stopEvent = (event: Event) => {
     event.preventDefault();
@@ -57,6 +60,14 @@ function setupInvokeWindowWinTabBridge() {
     return (event.buttons & 1) === 1;
   };
 
+  const hasNonPrimaryButton = (event: MouseEvent | PointerEvent) => {
+    if (event.button === 1 || event.button === 2) {
+      return true;
+    }
+
+    return (event.buttons & ~1) !== 0;
+  };
+
   const shouldSuppressNativeEvent = (event: Event) => {
     if (!bridgeEnabled) {
       return false;
@@ -72,6 +83,16 @@ function setupInvokeWindowWinTabBridge() {
 
     if (event instanceof PointerEvent && event.pointerType === 'pen') {
       return true;
+    }
+
+    if (syntheticPenSessionActive) {
+      if (event instanceof PointerEvent && event.pointerType === 'mouse') {
+        return hasNonPrimaryButton(event);
+      }
+
+      if (event instanceof MouseEvent) {
+        return hasNonPrimaryButton(event);
+      }
     }
 
     const now = performance.now();
@@ -181,12 +202,113 @@ function setupInvokeWindowWinTabBridge() {
     }
   };
 
+  const buildPayloadFromMouseEvent = (event: MouseEvent): WinTabPenEventPayload => ({
+    kind: 'up',
+    clientX: event.clientX,
+    clientY: event.clientY,
+    screenX: event.screenX,
+    screenY: event.screenY,
+    pressure: 0,
+    buttons: 0,
+  });
+
   const getElementTarget = (target: EventTarget | null): Element | null => {
     return target instanceof Element ? target : null;
   };
 
   const getCurrentHoverTarget = (payload: WinTabPenEventPayload) => {
     return document.elementFromPoint(payload.clientX, payload.clientY) ?? activeTarget ?? document.body;
+  };
+
+  const isSyntheticMouseTarget = (target: EventTarget | null) => {
+    const element = getElementTarget(target);
+    if (!element) {
+      return false;
+    }
+
+    if (element instanceof HTMLCanvasElement) {
+      return false;
+    }
+
+    return Boolean(
+      element.closest(
+        [
+          'button',
+          'a[href]',
+          'input',
+          'select',
+          'textarea',
+          'label',
+          'summary',
+          '[role="button"]',
+          '[role="link"]',
+          '[role="checkbox"]',
+          '[role="radio"]',
+          '[role="switch"]',
+          '[role="tab"]',
+          '[role="menuitem"]',
+          '[role="option"]',
+          '[role="slider"]',
+          '[contenteditable="true"]',
+        ].join(',')
+      )
+    );
+  };
+
+  const dismissTransientUi = (payload: WinTabPenEventPayload) => {
+    const activeElement = document.activeElement;
+    if (activeElement instanceof HTMLElement && activeElement !== document.body) {
+      activeElement.blur();
+    }
+
+    const dismissTarget = document.body ?? document.documentElement;
+    if (dismissTarget) {
+      const mouseDown = new MouseEvent('mousedown', {
+        bubbles: true,
+        cancelable: true,
+        composed: true,
+        clientX: payload.clientX,
+        clientY: payload.clientY,
+        screenX: payload.screenX,
+        screenY: payload.screenY,
+        button: 0,
+        buttons: 1,
+        detail: 1,
+      });
+      const mouseUp = new MouseEvent('mouseup', {
+        bubbles: true,
+        cancelable: true,
+        composed: true,
+        clientX: payload.clientX,
+        clientY: payload.clientY,
+        screenX: payload.screenX,
+        screenY: payload.screenY,
+        button: 0,
+        buttons: 0,
+        detail: 1,
+      });
+      const click = new MouseEvent('click', {
+        bubbles: true,
+        cancelable: true,
+        composed: true,
+        clientX: payload.clientX,
+        clientY: payload.clientY,
+        screenX: payload.screenX,
+        screenY: payload.screenY,
+        button: 0,
+        buttons: 0,
+        detail: 1,
+      });
+
+      dispatchingSyntheticMouseEvent = true;
+      try {
+        dismissTarget.dispatchEvent(mouseDown);
+        dismissTarget.dispatchEvent(mouseUp);
+        dismissTarget.dispatchEvent(click);
+      } finally {
+        dispatchingSyntheticMouseEvent = false;
+      }
+    }
   };
 
   const resolveClickTarget = (currentTarget: EventTarget | null) => {
@@ -216,15 +338,99 @@ function setupInvokeWindowWinTabBridge() {
     return getCurrentHoverTarget(payload);
   };
 
+  const endSyntheticPenSession = (payload: WinTabPenEventPayload) => {
+    if (!syntheticPenSessionActive) {
+      activeTarget = null;
+      syntheticMouseSessionActive = false;
+      return;
+    }
+
+    const upTarget = getCurrentHoverTarget(payload);
+    const pointerTarget = activeTarget ?? upTarget;
+    const clickTarget = syntheticMouseSessionActive ? resolveClickTarget(upTarget) : null;
+
+    dispatchSyntheticPointer(pointerTarget, 'pointerup', payload);
+    if (syntheticMouseSessionActive) {
+      dispatchSyntheticMouse(pointerTarget, 'mouseup', payload);
+    }
+    if (clickTarget) {
+      dispatchSyntheticMouse(clickTarget, 'click', payload);
+    }
+
+    activeTarget = null;
+    syntheticPenSessionActive = false;
+    syntheticMouseSessionActive = false;
+    suppressPrimaryMouseUntil = performance.now() + SUPPRESS_PRIMARY_MOUSE_GRACE_MS;
+  };
+
+  const updateAuxMouseState = (event: MouseEvent) => {
+    activeAuxMouseButtons = event.buttons & ~1;
+
+    if (dispatchingSyntheticMouseEvent || event.button === 0 || !syntheticPenSessionActive) {
+      return;
+    }
+
+    endSyntheticPenSession(buildPayloadFromMouseEvent(event));
+  };
+
+  const installMouseButtonTracking = () => {
+    if (mouseTrackingInstalled) {
+      return;
+    }
+
+    mouseTrackingInstalled = true;
+    const mouseEvents = ['mousedown', 'mousemove', 'mouseup'];
+    for (const eventType of mouseEvents) {
+      window.addEventListener(
+        eventType,
+        (event) => {
+          if (!(event instanceof MouseEvent)) {
+            return;
+          }
+          updateAuxMouseState(event);
+        },
+        true
+      );
+    }
+
+    window.addEventListener(
+      'blur',
+      () => {
+        activeAuxMouseButtons = 0;
+      },
+      true
+    );
+
+    document.addEventListener(
+      'visibilitychange',
+      () => {
+        if (document.visibilityState !== 'visible') {
+          activeAuxMouseButtons = 0;
+        }
+      },
+      true
+    );
+  };
+
   ipcRenderer.on(WINTAB_STATUS_CHANNEL, (_event, status: WinTabStatusPayload) => {
     bridgeEnabled = status.enabled;
     if (bridgeEnabled) {
       installSuppression();
+      installMouseButtonTracking();
     }
   });
 
   ipcRenderer.on(WINTAB_EVENT_CHANNEL, (_event, payload: WinTabPenEventPayload) => {
     if (!bridgeEnabled) {
+      return;
+    }
+
+    if (activeAuxMouseButtons !== 0) {
+      if (payload.kind === 'up') {
+        activeTarget = null;
+        syntheticPenSessionActive = false;
+        syntheticMouseSessionActive = false;
+      }
       return;
     }
 
@@ -234,33 +440,37 @@ function setupInvokeWindowWinTabBridge() {
     }
 
     if (payload.kind === 'down') {
-      activeTarget = target;
+      let dispatchTarget = target;
+      let shouldUseSyntheticMouse = isSyntheticMouseTarget(dispatchTarget);
+      if (!shouldUseSyntheticMouse) {
+        dismissTransientUi(payload);
+        dispatchTarget = getCurrentHoverTarget(payload);
+        shouldUseSyntheticMouse = isSyntheticMouseTarget(dispatchTarget);
+      }
+
+      activeTarget = dispatchTarget;
       syntheticPenSessionActive = true;
-      dispatchSyntheticPointer(target, 'pointerdown', payload);
-      dispatchSyntheticMouse(target, 'mousedown', payload);
+      syntheticMouseSessionActive = shouldUseSyntheticMouse;
+      dispatchSyntheticPointer(dispatchTarget, 'pointerdown', payload);
+      if (syntheticMouseSessionActive) {
+        dispatchSyntheticMouse(dispatchTarget, 'mousedown', payload);
+      }
       return;
     }
 
     if (payload.kind === 'move') {
-      syntheticPenSessionActive = true;
+      if (!syntheticPenSessionActive) {
+        return;
+      }
       dispatchSyntheticPointer(activeTarget ?? target, 'pointermove', payload);
-      dispatchSyntheticMouse(getCurrentHoverTarget(payload), 'mousemove', payload);
+      if (syntheticMouseSessionActive) {
+        dispatchSyntheticMouse(getCurrentHoverTarget(payload), 'mousemove', payload);
+      }
       return;
     }
 
     if (payload.kind === 'up') {
-      const upTarget = getCurrentHoverTarget(payload);
-      const pointerTarget = activeTarget ?? upTarget;
-      const clickTarget = resolveClickTarget(upTarget);
-
-      dispatchSyntheticPointer(pointerTarget, 'pointerup', payload);
-      dispatchSyntheticMouse(pointerTarget, 'mouseup', payload);
-      if (clickTarget) {
-        dispatchSyntheticMouse(clickTarget, 'click', payload);
-      }
-      activeTarget = null;
-      syntheticPenSessionActive = false;
-      suppressPrimaryMouseUntil = performance.now() + SUPPRESS_PRIMARY_MOUSE_GRACE_MS;
+      endSyntheticPenSession(payload);
     }
   });
 }

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -1,3 +1,266 @@
 import { exposeElectronAPI } from '@electron-toolkit/preload';
+import { ipcRenderer } from 'electron';
 
-exposeElectronAPI();
+const IS_INVOKE_HOSTED_WINDOW = process.argv.includes('--invoke-hosted-window');
+const WINTAB_STATUS_CHANNEL = 'invoke-window:wintab-status';
+const WINTAB_EVENT_CHANNEL = 'invoke-window:wintab-pen-event';
+const SYNTHETIC_POINTER_ID = 424242;
+const SUPPRESS_PRIMARY_MOUSE_GRACE_MS = 200;
+
+type WinTabStatusPayload = {
+  enabled: boolean;
+  message: string;
+};
+
+type WinTabPenEventPayload = {
+  kind: 'down' | 'move' | 'up';
+  clientX: number;
+  clientY: number;
+  screenX: number;
+  screenY: number;
+  pressure: number;
+  buttons: number;
+};
+
+if (IS_INVOKE_HOSTED_WINDOW) {
+  setupInvokeWindowWinTabBridge();
+} else {
+  exposeElectronAPI();
+}
+
+function setupInvokeWindowWinTabBridge() {
+  let bridgeEnabled = false;
+  let suppressionInstalled = false;
+  let syntheticPenSessionActive = false;
+  let suppressPrimaryMouseUntil = 0;
+  let activeTarget: EventTarget | null = null;
+  let dispatchingSyntheticMouseEvent = false;
+
+  const stopEvent = (event: Event) => {
+    event.preventDefault();
+    event.stopImmediatePropagation();
+  };
+
+  const isSyntheticWinTabPointerEvent = (event: Event) => {
+    return event instanceof PointerEvent && event.pointerId === SYNTHETIC_POINTER_ID && event.pointerType === 'pen';
+  };
+
+  const hasPrimaryButton = (event: MouseEvent | PointerEvent) => {
+    if (event.type === 'mouseup' || event.type === 'pointerup') {
+      return true;
+    }
+
+    if (event.button === 0) {
+      return true;
+    }
+
+    return (event.buttons & 1) === 1;
+  };
+
+  const shouldSuppressNativeEvent = (event: Event) => {
+    if (!bridgeEnabled) {
+      return false;
+    }
+
+    if (dispatchingSyntheticMouseEvent) {
+      return false;
+    }
+
+    if (isSyntheticWinTabPointerEvent(event)) {
+      return false;
+    }
+
+    if (event instanceof PointerEvent && event.pointerType === 'pen') {
+      return true;
+    }
+
+    const now = performance.now();
+    if (!syntheticPenSessionActive && now > suppressPrimaryMouseUntil) {
+      return false;
+    }
+
+    if (event instanceof PointerEvent && event.pointerType === 'mouse') {
+      return hasPrimaryButton(event);
+    }
+
+    if (event instanceof MouseEvent) {
+      return hasPrimaryButton(event);
+    }
+
+    return false;
+  };
+
+  const suppressionHandler = (event: Event) => {
+    if (shouldSuppressNativeEvent(event)) {
+      stopEvent(event);
+    }
+  };
+
+  const installSuppression = () => {
+    if (suppressionInstalled) {
+      return;
+    }
+
+    suppressionInstalled = true;
+    const pointerEvents = [
+      'pointerdown',
+      'pointermove',
+      'pointerup',
+      'pointerenter',
+      'pointerleave',
+      'pointerover',
+      'pointerout',
+      'pointercancel',
+      'mousedown',
+      'mousemove',
+      'mouseup',
+      'click',
+      'auxclick',
+      'contextmenu',
+    ];
+
+    for (const eventType of pointerEvents) {
+      window.addEventListener(eventType, suppressionHandler, true);
+    }
+  };
+
+  const dispatchSyntheticPointer = (target: EventTarget, eventType: string, payload: WinTabPenEventPayload) => {
+    if (!(target instanceof Element || target instanceof Document || target instanceof Window)) {
+      return;
+    }
+
+    const event = new PointerEvent(eventType, {
+      pointerId: SYNTHETIC_POINTER_ID,
+      pointerType: 'pen',
+      isPrimary: true,
+      bubbles: true,
+      cancelable: true,
+      composed: true,
+      clientX: payload.clientX,
+      clientY: payload.clientY,
+      screenX: payload.screenX,
+      screenY: payload.screenY,
+      pressure: payload.kind === 'up' ? 0 : payload.pressure,
+      button: payload.kind === 'move' ? -1 : 0,
+      buttons: payload.kind === 'up' ? 0 : 1,
+      width: 1,
+      height: 1,
+    });
+
+    target.dispatchEvent(event);
+  };
+
+  const dispatchSyntheticMouse = (
+    target: EventTarget,
+    eventType: 'mousedown' | 'mousemove' | 'mouseup' | 'click',
+    payload: WinTabPenEventPayload
+  ) => {
+    if (!(target instanceof Element || target instanceof Document || target instanceof Window)) {
+      return;
+    }
+
+    const buttons = eventType === 'mouseup' || eventType === 'click' ? 0 : 1;
+    const event = new MouseEvent(eventType, {
+      bubbles: true,
+      cancelable: true,
+      composed: true,
+      clientX: payload.clientX,
+      clientY: payload.clientY,
+      screenX: payload.screenX,
+      screenY: payload.screenY,
+      button: 0,
+      buttons,
+      detail: eventType === 'click' ? 1 : 0,
+    });
+
+    dispatchingSyntheticMouseEvent = true;
+    try {
+      target.dispatchEvent(event);
+    } finally {
+      dispatchingSyntheticMouseEvent = false;
+    }
+  };
+
+  const getElementTarget = (target: EventTarget | null): Element | null => {
+    return target instanceof Element ? target : null;
+  };
+
+  const getCurrentHoverTarget = (payload: WinTabPenEventPayload) => {
+    return document.elementFromPoint(payload.clientX, payload.clientY) ?? activeTarget ?? document.body;
+  };
+
+  const resolveClickTarget = (currentTarget: EventTarget | null) => {
+    const downTarget = getElementTarget(activeTarget);
+    const upTarget = getElementTarget(currentTarget);
+
+    if (!downTarget) {
+      return currentTarget;
+    }
+
+    if (!upTarget) {
+      return downTarget;
+    }
+
+    if (downTarget === upTarget || downTarget.contains(upTarget) || upTarget.contains(downTarget)) {
+      return downTarget;
+    }
+
+    return null;
+  };
+
+  const getDispatchTarget = (payload: WinTabPenEventPayload) => {
+    if (payload.kind === 'up' && activeTarget) {
+      return activeTarget;
+    }
+
+    return getCurrentHoverTarget(payload);
+  };
+
+  ipcRenderer.on(WINTAB_STATUS_CHANNEL, (_event, status: WinTabStatusPayload) => {
+    bridgeEnabled = status.enabled;
+    if (bridgeEnabled) {
+      installSuppression();
+    }
+  });
+
+  ipcRenderer.on(WINTAB_EVENT_CHANNEL, (_event, payload: WinTabPenEventPayload) => {
+    if (!bridgeEnabled) {
+      return;
+    }
+
+    const target = getDispatchTarget(payload);
+    if (!target) {
+      return;
+    }
+
+    if (payload.kind === 'down') {
+      activeTarget = target;
+      syntheticPenSessionActive = true;
+      dispatchSyntheticPointer(target, 'pointerdown', payload);
+      dispatchSyntheticMouse(target, 'mousedown', payload);
+      return;
+    }
+
+    if (payload.kind === 'move') {
+      syntheticPenSessionActive = true;
+      dispatchSyntheticPointer(activeTarget ?? target, 'pointermove', payload);
+      dispatchSyntheticMouse(getCurrentHoverTarget(payload), 'mousemove', payload);
+      return;
+    }
+
+    if (payload.kind === 'up') {
+      const upTarget = getCurrentHoverTarget(payload);
+      const pointerTarget = activeTarget ?? upTarget;
+      const clickTarget = resolveClickTarget(upTarget);
+
+      dispatchSyntheticPointer(pointerTarget, 'pointerup', payload);
+      dispatchSyntheticMouse(pointerTarget, 'mouseup', payload);
+      if (clickTarget) {
+        dispatchSyntheticMouse(clickTarget, 'click', payload);
+      }
+      activeTarget = null;
+      syntheticPenSessionActive = false;
+      suppressPrimaryMouseUntil = performance.now() + SUPPRESS_PRIMARY_MOUSE_GRACE_MS;
+    }
+  });
+}

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -226,33 +226,7 @@ function setupInvokeWindowWinTabBridge() {
       return false;
     }
 
-    if (element instanceof HTMLCanvasElement) {
-      return false;
-    }
-
-    return Boolean(
-      element.closest(
-        [
-          'button',
-          'a[href]',
-          'input',
-          'select',
-          'textarea',
-          'label',
-          'summary',
-          '[role="button"]',
-          '[role="link"]',
-          '[role="checkbox"]',
-          '[role="radio"]',
-          '[role="switch"]',
-          '[role="tab"]',
-          '[role="menuitem"]',
-          '[role="option"]',
-          '[role="slider"]',
-          '[contenteditable="true"]',
-        ].join(',')
-      )
-    );
+    return element.closest('canvas') === null;
   };
 
   const dismissTransientUi = (payload: WinTabPenEventPayload) => {

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -4,6 +4,7 @@ import { ipcRenderer } from 'electron';
 const IS_INVOKE_HOSTED_WINDOW = process.argv.includes('--invoke-hosted-window');
 const WINTAB_STATUS_CHANNEL = 'invoke-window:wintab-status';
 const WINTAB_EVENT_CHANNEL = 'invoke-window:wintab-pen-event';
+const WINTAB_ACK_CHANNEL = 'invoke-window:wintab-pen-event-ack';
 const SYNTHETIC_POINTER_ID = 424242;
 const SUPPRESS_PRIMARY_MOUSE_GRACE_MS = 200;
 
@@ -394,7 +395,7 @@ function setupInvokeWindowWinTabBridge() {
     }
   });
 
-  ipcRenderer.on(WINTAB_EVENT_CHANNEL, (_event, payload: WinTabPenEventPayload) => {
+  const processWinTabEvent = (payload: WinTabPenEventPayload) => {
     if (!bridgeEnabled) {
       return;
     }
@@ -445,6 +446,16 @@ function setupInvokeWindowWinTabBridge() {
 
     if (payload.kind === 'up') {
       endSyntheticPenSession(payload);
+    }
+  };
+
+  ipcRenderer.on(WINTAB_EVENT_CHANNEL, (_event, payloads: WinTabPenEventPayload[]) => {
+    try {
+      for (const payload of payloads) {
+        processWinTabEvent(payload);
+      }
+    } finally {
+      ipcRenderer.send(WINTAB_ACK_CHANNEL);
     }
   });
 }


### PR DESCRIPTION
## Summary

This PR improves Windows tablet behavior in the launcher for devices where the stylus side buttons are mapped by the driver to standard mouse buttons.

The key change is to stop relying on Chromium/Electron to interpret the entire tablet input stream on its own. Instead:

- stylus side buttons continue to use the normal mouse path
- pen contact and pressure are routed through a native WinTab bridge

This matches the intended behavior on the affected hardware: pen is only needed for contact + pressure, while buttons should behave exactly like mouse input.

## Problem

On the affected Windows tablet setup, Chromium/Electron does not handle the split between tablet input and compatibility mouse input reliably under Windows Ink.

In practice this caused issues such as:

- hover pan started by stylus `MMB` getting stuck on release
- stylus `RMB` behaving inconsistently
- pen contact / pressure conflicting with Chromium's primary pen/mouse path

The root issue is not canvas logic itself, but limited tablet-input handling in Chromium/Electron for this kind of mixed input path.

## Approach

This PR adds a Windows-only native WinTab bridge and uses it only for the primary pen contact path:

- add a native `wintab-pen-bridge` module
- use WinTab for pen contact and pressure
- keep driver-mapped stylus side buttons on the normal mouse path
- suppress the conflicting primary pen/mouse path before Chromium handles it
- forward synthetic pen contact events into the hosted Invoke UI through preload

## Scope

This PR is intentionally limited to the Windows tablet-input fix in the launcher.

It does not include unrelated release/process/infrastructure changes.

## Notes

- Windows-only behavior change
- non-Windows behavior should remain unchanged
- this path depends on a WinTab-capable driver
