### PR TITLE
Async Windows code signing via OSSign (dispatch + wait loop)

### DIFF
--- a/.github/ossign/README.md
+++ b/.github/ossign/README.md
@@ -9,38 +9,44 @@ This replaces the previous DigiCert KeyLocker signing that ran directly inside
 
 ## How it works
 
+OSSign's signing requires a **manual reviewer approval on their side that can take hours**, so we
+do not hold a runner waiting. Instead we dispatch and then poll asynchronously via a cheap
+wait-timer loop:
+
 ```
-invoke-ai/launcher                         OSSign (api.ossign.org)            OSSign/invoke-ai-launcher
-─────────────────────                      ──────────────────────            ─────────────────────────
-build-and-sign.yml
-  build-windows job
-    ossign/actions/workflow/dispatch  ───▶  dispatch/<user>            ───▶  "Build and Sign" workflow
-                                                                               (.github/workflows/build-and-sign.yml
-                                                                                in the OSSign-hosted repo)
-                                                                                 - checkout invoke-ai/launcher@<ref>
-                                                                                 - npm run package (ENABLE_SIGNING)
+invoke-ai/launcher                              OSSign (api.ossign.org)        OSSign/invoke-ai-launcher
+─────────────────────                           ──────────────────────        ─────────────────────────
+build-and-sign.yml :: build-windows
+  dispatch (dispatch_only: true)           ───▶  dispatch/<user>          ───▶  "Build and Sign" workflow
+    -> returns workflow_id                                                        - checkout invoke-ai/launcher@<ref>
+  gh workflow run wait-signature.yml                                              - npm run package (ENABLE_SIGNING)
                                                                                      -> scripts/customSign.js
-                                                                                        -> OSSign CLI + OSSIGN_CONFIG
-                                                                                 - publish signed release
-    (polls until complete)            ◀───  check/<user>/<id>          ◀───  release assets
-    downloads signed_artifacts
-    uploads windows-artifacts-signed
+wait-signature.yml  (loops)                                                          -> OSSign CLI + OSSIGN_CONFIG
+  [Signatures env wait timer ~20 min]                                            - publish signed release  ─┐
+  single_check(workflow_id)              ◀────  check/<user>/<id>          ◀──── release assets  ◀──────────┘
+    - not done -> re-dispatch self (next interval)
+    - done     -> download signed_artifacts
+                  attach .exe/.blockmap/latest.yml to the vX.Y.Z GitHub Release
 ```
 
-1. When a `v*` tag is pushed (or the workflow is dispatched), the `build-windows` job in
-   `.github/workflows/build-and-sign.yml` calls `ossign/actions/workflow/dispatch@main` with our
-   OSSign credentials. The action uses the **current git ref** as the `source_branch`.
-2. The OSSign API triggers the **Build and Sign** workflow in
+1. When a `v*` tag is pushed (or the workflow is dispatched), `build-windows` calls
+   `ossign/actions/workflow/dispatch` with `dispatch_only: true`. The action uses the **current
+   git ref** as the `source_branch` and returns a `workflow_id` immediately (no waiting).
+2. `build-windows` kicks off `wait-signature.yml` (passing the `workflow_id` and the target ref),
+   then finishes in seconds.
+3. The OSSign API triggers the **Build and Sign** workflow in
    [`OSSign/invoke-ai-launcher`](https://github.com/OSSign/invoke-ai-launcher/blob/main/.github/workflows/build-and-sign.yml)
-   — that repo holds the canonical, maintained copy of the workflow. It checks out
-   `invoke-ai/launcher` at the requested ref, builds the NSIS installer, and signs it via
-   `scripts/customSign.js` using the `OSSIGN_CONFIG` certificate provisioned in OSSign's `OSSign`
-   environment.
-3. The signed files are published as a GitHub release in the OSSign repo. The dispatch action
-   polls until completion, then returns the signed release assets.
-4. Back in `invoke-ai/launcher`, the `build-windows` job downloads those signed artifacts and
-   uploads them as `windows-artifacts-signed`, matching the previous job's output so the rest of
-   the release flow is unchanged.
+   — the canonical, maintained copy. It checks out `invoke-ai/launcher` at the requested ref,
+   builds the NSIS installer, signs it via `scripts/customSign.js` using the `OSSIGN_CONFIG`
+   certificate (provisioned in OSSign's `OSSign` environment, behind their reviewer gate), and
+   publishes the signed files as a release in the OSSign repo.
+4. `wait-signature.yml` polls: each run waits out the `Signatures` environment's Wait timer
+   (~20 min, consuming no runner minutes while queued), does one `single_check`, and—if signing
+   isn't done—re-dispatches itself for the next interval (up to `max_attempts`, default 72 ≈ 24h).
+5. Once signing completes, the loop downloads the signed artifacts and, for a `vX.Y.Z` tag,
+   attaches them (`.exe`, `.blockmap`, `latest.yml`) to that tag's GitHub Release — alongside the
+   Linux/macOS installers already published there by their build jobs. (Non-tag test runs stop at
+   a `windows-artifacts-signed` workflow artifact, since there is no release to attach to.)
 
 Linux and macOS builds are unaffected and continue to build/sign in
 `.github/workflows/build-and-sign.yml`.
@@ -63,10 +69,12 @@ It already builds and signs using the approach above: it checks out `invoke-ai/l
 OSSign-hosted workflow may need a matching update — open a PR against `OSSign/invoke-ai-launcher`
 and notify OSSign for review.
 
-### 2. Add the dispatch credentials to this repository
+### 2. Add the dispatch credentials as repo-level secrets
 
-The `build-windows` job authenticates to the OSSign API with two secrets. Add them to the
-`code-signing` environment (the same environment the other signing jobs use):
+Both the `build-windows` job (no environment) and the `wait-signature.yml` loop (which runs in the
+`Signatures` environment for its Wait timer) authenticate to the OSSign API. So these must be
+**repository-level** secrets, not environment secrets — an environment secret scoped to one
+environment would not be visible to both:
 
 | Secret         | Value                                      |
 | -------------- | ------------------------------------------ |
@@ -74,12 +82,25 @@ The `build-windows` job authenticates to the OSSign API with two secrets. Add th
 | `OSSIGN_TOKEN` | the OSSign API token                       |
 
 ```bash
-gh secret set OSSIGN_USER  --env code-signing --repo invoke-ai/launcher
-gh secret set OSSIGN_TOKEN --env code-signing --repo invoke-ai/launcher
+# repo-level (note: NO --env flag)
+gh secret set OSSIGN_USER  --repo invoke-ai/launcher
+gh secret set OSSIGN_TOKEN --repo invoke-ai/launcher
 ```
+
+If these were previously added to the `code-signing` environment, remove those copies — they are
+no longer used there (`gh secret delete OSSIGN_USER --env code-signing --repo invoke-ai/launcher`).
 
 > The certificate config (`OSSIGN_CONFIG`) is **not** stored here — OSSign provisions it in the
 > `OSSign` environment of `OSSign/invoke-ai-launcher`.
+
+### 2b. Create the `Signatures` environment (one-time)
+
+`wait-signature.yml` relies on a `Signatures` environment whose **Wait timer** provides the polling
+interval. It must have **no required reviewers** (or every poll would block on approval):
+
+```bash
+gh api -X PUT repos/invoke-ai/launcher/environments/Signatures -F wait_timer=20
+```
 
 ### 3. Clean up the old DigiCert secrets (optional)
 

--- a/.github/workflows/build-and-sign.yml
+++ b/.github/workflows/build-and-sign.yml
@@ -176,63 +176,52 @@ jobs:
             dist/*.yaml
           retention-days: 90
 
-  # Windows builds are produced and code-signed by OSSign's hosted infrastructure
-  # (https://ossign.org); the signing certificate never enters this repository. We
-  # dispatch a build+sign request to OSSign, which checks out this repo at the current
-  # ref, builds the NSIS installer and signs it, then publishes the signed files. We
-  # wait for completion, download the signed artifacts, and re-upload them under the
-  # same `windows-artifacts-signed` name the rest of the release flow expects.
+  # Windows builds are code-signed by OSSign's hosted infrastructure (https://ossign.org);
+  # the signing certificate never enters this repository. OSSign's signing requires a manual
+  # reviewer approval on their side that can take HOURS, so we do not hold a runner waiting
+  # (it would just hit the job timeout). Instead this job fire-and-forgets the dispatch
+  # (dispatch_only) and hands the returned workflow id to wait-signature.yml, which polls on
+  # a cheap timer (the "Signatures" environment's Wait timer) and, once OSSign finishes,
+  # downloads the signed artifacts and attaches them to this tag's GitHub Release.
   #
-  # The OSSign-side workflow lives in OSSign/invoke-ai-launcher; the version we maintain
-  # for it, plus setup instructions, are checked in under .github/ossign/.
+  # This job intentionally uses no environment: it holds no signing cert (OSSign does), and
+  # the code-signing environment's required-reviewer gate would needlessly delay the dispatch.
+  # OSSIGN_USER / OSSIGN_TOKEN are therefore repo-level secrets (also read by wait-signature.yml,
+  # which runs in the Signatures environment).
+  #
+  # The OSSign-side workflow lives in OSSign/invoke-ai-launcher; the version we maintain for it,
+  # plus setup instructions, are checked in under .github/ossign/.
   build-windows:
     if: github.event_name == 'push' || github.event.inputs.build_windows == 'true'
     runs-on: ubuntu-latest
-    environment: code-signing
-    # Building + signing on OSSign's infrastructure can take a while; allow for it.
-    timeout-minutes: 90
+    timeout-minutes: 10
+    permissions:
+      contents: read
+      actions: write # needed to dispatch the wait-signature.yml polling workflow
 
     steps:
-      - name: Dispatch build & sign to OSSign and wait for signed artifacts
+      - name: Dispatch build & sign to OSSign (fire-and-forget)
         id: ossign
         # Pinned to a commit SHA (not a mutable @main) — this action receives OSSIGN_TOKEN,
         # so a moving ref is a supply-chain risk. Bump deliberately (e.g. via Dependabot).
         uses: ossign/actions/workflow/dispatch@fbf0b39466d9409f05d1efc0e58cc3e4615ac625 # OSSign/actions main @ 2025-10-09
         with:
-          # OSSign maps these credentials to the OSSign/invoke-ai-launcher repo and
-          # triggers its "Build and Sign" workflow. The source ref is taken from the
-          # current ref of this workflow run (the pushed tag or dispatched branch).
+          # OSSign maps these credentials to the OSSign/invoke-ai-launcher repo and triggers its
+          # "Build and Sign" workflow. The source ref is taken from the current ref of this run
+          # (the pushed tag or dispatched branch).
           username: ${{ secrets.OSSIGN_USER }}
           token: ${{ secrets.OSSIGN_TOKEN }}
-          # dispatch_only defaults to false: block until signing completes and expose
-          # the signed release assets via the `signed_artifacts` output.
+          # Return immediately with a workflow id; the wait loop polls for the signed result.
+          dispatch_only: true
 
-      - name: Download signed Windows artifacts
+      - name: Start the signing wait loop
         env:
-          SIGNED_ARTIFACTS: ${{ steps.ossign.outputs.signed_artifacts }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -euo pipefail
-          mkdir -p dist
-          if [ -z "${SIGNED_ARTIFACTS:-}" ] || [ "${SIGNED_ARTIFACTS}" = "[]" ]; then
-            echo "::error::OSSign returned no signed artifacts"
-            exit 1
-          fi
-          echo "${SIGNED_ARTIFACTS}" | jq -r '.[] | [.name, .browser_download_url] | @tsv' \
-            | while IFS=$'\t' read -r name url; do
-                echo "Downloading signed artifact: ${name}"
-                curl -fSL "${url}" -o "dist/${name}"
-              done
-          echo "Downloaded signed artifacts:"
-          ls -l dist
-
-      - name: Upload artifacts
-        uses: actions/upload-artifact@v4
-        with:
-          name: 'windows-artifacts-signed'
-          path: |
-            dist/*.exe
-            dist/*.EXE
-            dist/*.blockmap
-            dist/*.yml
-            dist/*.yaml
-          retention-days: 90
+          echo "OSSign signing dispatched (workflow id: ${{ steps.ossign.outputs.workflow_id }})."
+          gh workflow run wait-signature.yml \
+            --ref "${{ github.ref_name }}" \
+            -f workflow_id="${{ steps.ossign.outputs.workflow_id }}" \
+            -f target_ref="${{ github.ref_name }}" \
+            -f attempt=1

--- a/.github/workflows/wait-signature.yml
+++ b/.github/workflows/wait-signature.yml
@@ -1,0 +1,125 @@
+name: OSSign Signing Wait Loop
+
+# Polls OSSign for a previously-dispatched Windows signing request and, once it completes,
+# downloads the signed artifacts and attaches them to the matching GitHub Release.
+#
+# Why a self-re-dispatching loop instead of a single waiting job? OSSign's signing requires a
+# manual reviewer approval on their side that can take *hours*. GitHub Actions cannot pause a
+# job cheaply, so we exploit the "Signatures" environment's Wait timer: each run waits out the
+# timer (consuming no runner minutes while queued), does one status check, and—if not yet
+# done—re-dispatches itself for the next interval. Total max wait = wait_timer * max_attempts.
+#
+# Started by the build-windows job in build-and-sign.yml. See .github/ossign/README.md.
+
+on:
+  workflow_dispatch:
+    inputs:
+      workflow_id:
+        description: 'The OSSign dispatch workflow id to poll'
+        required: true
+        type: string
+      target_ref:
+        description: 'Ref the signed artifacts belong to. A vX.Y.Z tag is attached to that GitHub Release; anything else is kept only as a workflow artifact.'
+        required: true
+        type: string
+      attempt:
+        description: 'Current attempt number'
+        required: false
+        type: number
+        default: 1
+      max_attempts:
+        description: 'Max attempts. wait_timer (20 min) * max_attempts = max total wait (72 -> ~24h).'
+        required: false
+        type: number
+        default: 72
+
+permissions:
+  contents: write # attach assets to the release
+  actions: write # re-dispatch this workflow for the next poll
+
+jobs:
+  wait-and-check:
+    runs-on: ubuntu-latest
+    # The Wait timer protection rule on this environment provides the polling interval.
+    # It must have NO required reviewers, or every poll iteration would block on approval.
+    environment: Signatures
+    timeout-minutes: 10
+
+    steps:
+      - name: Enforce attempt ceiling
+        run: |
+          set -euo pipefail
+          if [ "${{ inputs.attempt }}" -gt "${{ inputs.max_attempts }}" ]; then
+            echo "::error::OSSign signing did not complete within ${{ inputs.max_attempts }} attempts (~$(( ${{ inputs.max_attempts }} * 20 / 60 ))h). Giving up."
+            exit 1
+          fi
+          echo "Attempt ${{ inputs.attempt }} of ${{ inputs.max_attempts }} for OSSign workflow ${{ inputs.workflow_id }}."
+
+      - name: Check OSSign signing status
+        id: check
+        # Pinned to a commit SHA (not a mutable @main) — this action receives OSSIGN_TOKEN,
+        # so a moving ref is a supply-chain risk. Bump deliberately (e.g. via Dependabot).
+        uses: ossign/actions/workflow/dispatch@fbf0b39466d9409f05d1efc0e58cc3e4615ac625 # OSSign/actions main @ 2025-10-09
+        with:
+          username: ${{ secrets.OSSIGN_USER }}
+          token: ${{ secrets.OSSIGN_TOKEN }}
+          single_check: ${{ inputs.workflow_id }}
+
+      - name: Download signed artifacts
+        if: steps.check.outputs.signed_artifacts != ''
+        env:
+          SIGNED_ARTIFACTS: ${{ steps.check.outputs.signed_artifacts }}
+        run: |
+          set -euo pipefail
+          mkdir -p dist
+          echo "${SIGNED_ARTIFACTS}" | jq -r '.[] | [.name, .browser_download_url] | @tsv' \
+            | while IFS=$'\t' read -r name url; do
+                echo "Downloading signed artifact: ${name}"
+                curl -fSL "${url}" -o "dist/${name}"
+              done
+          echo "Downloaded signed artifacts:"
+          ls -l dist
+
+      - name: Upload workflow artifact
+        if: steps.check.outputs.signed_artifacts != ''
+        uses: actions/upload-artifact@v4
+        with:
+          name: windows-artifacts-signed
+          path: |
+            dist/*.exe
+            dist/*.blockmap
+            dist/*.yml
+            dist/*.yaml
+          retention-days: 90
+
+      - name: Attach signed artifacts to the release
+        # Only for vX.Y.Z tags — the release is created by the linux/macOS publish jobs. For
+        # non-tag (manual test) runs there is no release, so we stop at the workflow artifact above.
+        if: steps.check.outputs.signed_artifacts != '' && startsWith(inputs.target_ref, 'v')
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          shopt -s nullglob
+          files=(dist/*.exe dist/*.blockmap dist/*.yml dist/*.yaml)
+          if [ ${#files[@]} -eq 0 ]; then
+            echo "::error::No signed Windows files found to attach to release ${{ inputs.target_ref }}"
+            exit 1
+          fi
+          echo "Attaching to release ${{ inputs.target_ref }}: ${files[*]}"
+          gh release upload "${{ inputs.target_ref }}" "${files[@]}" --clobber
+
+      - name: Not finished — schedule the next poll
+        if: steps.check.outputs.signed_artifacts == ''
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          next=$(( ${{ inputs.attempt }} + 1 ))
+          echo "OSSign signing not finished yet; scheduling attempt ${next}."
+          gh workflow run wait-signature.yml \
+            --ref "${{ github.ref_name }}" \
+            -f workflow_id="${{ inputs.workflow_id }}" \
+            -f target_ref="${{ inputs.target_ref }}" \
+            -f attempt="${next}" \
+            -f max_attempts="${{ inputs.max_attempts }}"

--- a/CODESIGN.md
+++ b/CODESIGN.md
@@ -37,19 +37,24 @@ Windows builds are code-signed by [OSSign](https://ossign.org)'s hosted infrastr
 The signing certificate lives only at OSSign and is **never** exposed to this repository.
 
 The `build-windows` job in `.github/workflows/build-and-sign.yml` does not build or sign
-Windows locally. Instead it uses `ossign/actions/workflow/dispatch` to trigger the "Build
-and Sign" workflow in our OSSign-hosted repo (`OSSign/invoke-ai-launcher`), waits for it to
-finish, and downloads the signed artifacts. That hosted workflow checks out this repo at the
-release ref, runs `npm run package` with `ENABLE_SIGNING=true`, and signs each binary via
-`scripts/customSign.js`, which delegates to the
-[`@ossign/ossign`](https://www.npmjs.com/package/@ossign/ossign) CLI using the certificate
-config (`OSSIGN_CONFIG`) that OSSign provisions in that repo.
+Windows locally. It fires a `dispatch_only` request via `ossign/actions/workflow/dispatch` to
+trigger the "Build and Sign" workflow in our OSSign-hosted repo (`OSSign/invoke-ai-launcher`),
+then hands the returned workflow id to `.github/workflows/wait-signature.yml`. Because OSSign's
+signing waits on a manual reviewer approval that can take hours, that wait loop polls
+asynchronously (using the `Signatures` environment's Wait timer) instead of holding a runner;
+when signing completes it downloads the signed artifacts and attaches them to the tag's GitHub
+Release. The hosted workflow checks out this repo at the release ref, runs `npm run package`
+with `ENABLE_SIGNING=true`, and signs each binary via `scripts/customSign.js`, which delegates
+to the [`@ossign/ossign`](https://www.npmjs.com/package/@ossign/ossign) CLI using the
+certificate config (`OSSIGN_CONFIG`) that OSSign provisions in that repo.
 
-See [`.github/ossign/README.md`](.github/ossign/README.md) for the full architecture. The
-OSSign-side workflow itself lives in the
+See [`.github/ossign/README.md`](.github/ossign/README.md) for the full architecture (including
+the `Signatures` environment setup). The OSSign-side workflow itself lives in the
 [`OSSign/invoke-ai-launcher`](https://github.com/OSSign/invoke-ai-launcher) repo.
 
-Two secrets must be set in this repo's `code-signing` environment (OSSign provides the values):
+Two **repo-level** secrets must be set (OSSign provides the values). They are repo-level rather
+than environment-scoped because both `build-windows` (no environment) and `wait-signature.yml`
+(the `Signatures` environment) need them:
 
 - `OSSIGN_USER`: the OSSign username used to authenticate the dispatch request.
 - `OSSIGN_TOKEN`: the OSSign API token used to authenticate the dispatch request.


### PR DESCRIPTION
Follow-up to #128 (the OSSign migration, now merged). #128 dispatched Windows signing **synchronously** and waited on a runner — but OSSign requires a manual reviewer approval on their side that can take **hours**, so the job hit its 90-minute timeout. This makes Windows signing asynchronous, per [OSSign's recommended dispatch + wait-loop pattern](https://github.com/OSSign/example-workflow/tree/ossign).

## What changed
- **`build-windows`** now does a **fire-and-forget** dispatch (`dispatch_only: true`), captures the returned `workflow_id`, and starts `wait-signature.yml`. It uses **no environment** (it holds no cert, and the `code-signing` reviewer gate would needlessly delay the dispatch) and finishes in seconds.
- **New `wait-signature.yml`** runs in a **`Signatures`** environment whose **Wait timer** (~20 min) provides the polling interval at *no runner cost*. Each run does one `single_check`; if signing isn't done it **re-dispatches itself** (up to `max_attempts`, default 72 ≈ 24h). On completion it downloads the signed artifacts and, for a `vX.Y.Z` tag, **attaches `.exe`/`.blockmap`/`latest.yml` to that GitHub Release** (alongside the Linux/macOS installers), so Windows downloads and auto-update work. Non-tag test runs stop at a `windows-artifacts-signed` workflow artifact.
- Docs (`.github/ossign/README.md`, `CODESIGN.md`) updated for the async flow.

## Required repo config (done out-of-band)
- [x] `Signatures` environment created with a 20-min Wait timer and **no reviewers** (`gh api -X PUT .../environments/Signatures -F wait_timer=20`).
- [ ] **Move `OSSIGN_USER` / `OSSIGN_TOKEN` to repo-level secrets** (they were env-scoped in `code-signing`; the wait job's `Signatures` environment can't see those). Remove the `code-signing` copies afterward.

## Testing note
`wait-signature.yml` is dispatched by name (`gh workflow run`), which requires it to exist on the **default branch** — so end-to-end testing only works **after this merges to `main`** (same constraint as before).

🤖 Generated with [Claude Code](https://claude.com/claude-code)