### PR TITLE
fix(signing): pass --repo to gh calls in non-checkout signing jobs

### DIFF
--- a/.github/workflows/build-and-sign.yml
+++ b/.github/workflows/build-and-sign.yml
@@ -220,7 +220,9 @@ jobs:
         run: |
           set -euo pipefail
           echo "OSSign signing dispatched (workflow id: ${{ steps.ossign.outputs.workflow_id }})."
+          # --repo is required: this job does not checkout, so gh has no local git context to infer it from.
           gh workflow run wait-signature.yml \
+            --repo "${{ github.repository }}" \
             --ref "${{ github.ref_name }}" \
             -f workflow_id="${{ steps.ossign.outputs.workflow_id }}" \
             -f target_ref="${{ github.ref_name }}" \

--- a/.github/workflows/wait-signature.yml
+++ b/.github/workflows/wait-signature.yml
@@ -107,7 +107,8 @@ jobs:
             exit 1
           fi
           echo "Attaching to release ${{ inputs.target_ref }}: ${files[*]}"
-          gh release upload "${{ inputs.target_ref }}" "${files[@]}" --clobber
+          # --repo is required: this job does not checkout, so gh has no local git context to infer it from.
+          gh release upload "${{ inputs.target_ref }}" "${files[@]}" --clobber --repo "${{ github.repository }}"
 
       - name: Not finished — schedule the next poll
         if: steps.check.outputs.signed_artifacts == ''
@@ -117,7 +118,9 @@ jobs:
           set -euo pipefail
           next=$(( ${{ inputs.attempt }} + 1 ))
           echo "OSSign signing not finished yet; scheduling attempt ${next}."
+          # --repo is required: this job does not checkout, so gh has no local git context to infer it from.
           gh workflow run wait-signature.yml \
+            --repo "${{ github.repository }}" \
             --ref "${{ github.ref_name }}" \
             -f workflow_id="${{ inputs.workflow_id }}" \
             -f target_ref="${{ inputs.target_ref }}" \


### PR DESCRIPTION
The first live test of the async OSSign wait loop (#129) surfaced a bug: the **dispatch to OSSign succeeded**, but the **"Start the signing wait loop" step failed** with:

```
failed to run git: fatal: not a git repository (or any of the parent directories): .git
```

`gh workflow run` and `gh release upload` infer the target repo from the local git checkout. The `build-windows` and `wait-signature` jobs never run `actions/checkout` (they only call APIs), so there's no git context and gh errors out — `GH_TOKEN` alone isn't enough.

**Fix:** pass `--repo "${{ github.repository }}"` to every `gh` call in those jobs (the kickoff in `build-and-sign.yml`, and the re-dispatch + release upload in `wait-signature.yml`).

Found via run [27094640995](https://github.com/invoke-ai/launcher/actions/runs/27094640995). After this merges I'll re-run the Windows-only test to confirm the loop launches and polls.

🤖 Generated with [Claude Code](https://claude.com/claude-code)