### PR TITLE
feat: add custom PyTorch index URL override

### DIFF
--- a/src/main/install-manager.ts
+++ b/src/main/install-manager.ts
@@ -13,6 +13,7 @@ import { DEFAULT_ENV } from '@/lib/pty-utils';
 import { withResultAsync } from '@/lib/result';
 import { SimpleLogger } from '@/lib/simple-logger';
 import { FIRST_RUN_MARKER_FILENAME } from '@/main/constants';
+import { store } from '@/main/store';
 import { getInstallationDetails, getTorchPlatform, getUVExecutablePath, isDirectory, isFile } from '@/main/util';
 import { getPins } from '@/shared/pins';
 import type {
@@ -188,7 +189,13 @@ export class InstallManager {
     }
 
     const pythonVersion = pinsResult.value.python;
-    const torchIndexUrl = pinsResult.value.torchIndexUrl[systemPlatform][torchPlatform];
+    const pinnedTorchIndexUrl = pinsResult.value.torchIndexUrl[systemPlatform][torchPlatform];
+
+    // An optional user-provided index URL overrides the pinned one. This is an advanced escape hatch for cases the pins
+    // can't cover (e.g. older Nvidia GPUs needing a different CUDA build, or AMD on Windows where there is no pinned
+    // index). The user is responsible for providing a working URL - an invalid one will break the install.
+    const customTorchIndexUrl = store.get('customTorchIndexUrl')?.trim() || undefined;
+    const torchIndexUrl = customTorchIndexUrl ?? pinnedTorchIndexUrl;
 
     const installationDetails = await getInstallationDetails(location);
 
@@ -218,6 +225,11 @@ export class InstallManager {
     this.log.info(`- GPU type: ${gpuType}\r\n`);
     this.log.info(`- Torch platform: ${torchPlatform}\r\n`);
     this.log.info(`- Using torch index: ${torchIndexUrl ?? 'default'}\r\n`);
+    if (customTorchIndexUrl) {
+      this.log.info(
+        c.magenta(`- Custom torch index URL override is active (set in Settings): ${customTorchIndexUrl}\r\n`)
+      );
+    }
 
     if (repair) {
       this.log.info(c.magenta('Repair mode enabled:\r\n'));

--- a/src/main/main-process-manager.ts
+++ b/src/main/main-process-manager.ts
@@ -30,7 +30,15 @@ export class MainProcessManager {
       this.sendToWindow('store:changed', data);
     });
     this.ipc.handle('store:get-key', (_, key) => this.store.get(key));
-    this.ipc.handle('store:set-key', (_, key, value) => this.store.set(key, value));
+    this.ipc.handle('store:set-key', (_, key, value) => {
+      // electron-store throws if you `set` a key to `undefined` - you must `delete` it instead. We treat setting a key
+      // to `undefined` as a request to clear it.
+      if (value === undefined) {
+        this.store.delete(key);
+      } else {
+        this.store.set(key, value);
+      }
+    });
     this.ipc.handle('store:get', (_) => this.store.store);
     this.ipc.handle('store:set', (_, data) => {
       this.store.store = data;

--- a/src/renderer/features/SettingsModal/SettingsModal.tsx
+++ b/src/renderer/features/SettingsModal/SettingsModal.tsx
@@ -14,6 +14,7 @@ import {
 import { useStore } from '@nanostores/react';
 import { memo, useCallback } from 'react';
 
+import { SettingsModalCustomTorchIndexUrl } from '@/renderer/features/SettingsModal/SettingsModalCustomTorchIndexUrl';
 import { SettingsModalInvokeNotifyForPrereleaseUpdates } from '@/renderer/features/SettingsModal/SettingsModalInvokeNotifyForPrereleaseUpdates';
 import { SettingsModalInvokeServerMode } from '@/renderer/features/SettingsModal/SettingsModalInvokeServerMode';
 import { SettingsModalOptInToLauncherPrereleases } from '@/renderer/features/SettingsModal/SettingsModalOptInToLauncherPrereleases';
@@ -39,6 +40,8 @@ export const SettingsModal = memo(() => {
           <SettingsModalInvokeNotifyForPrereleaseUpdates />
           <Divider />
           <SettingsModalOptInToLauncherPrereleases />
+          <Divider />
+          <SettingsModalCustomTorchIndexUrl />
         </ModalBody>
         <ModalFooter pt={16}>
           <SettingsModalResetButton />

--- a/src/renderer/features/SettingsModal/SettingsModalCustomTorchIndexUrl.tsx
+++ b/src/renderer/features/SettingsModal/SettingsModalCustomTorchIndexUrl.tsx
@@ -1,0 +1,40 @@
+import { Flex, FormControl, FormHelperText, FormLabel, Input } from '@invoke-ai/ui-library';
+import { useStore } from '@nanostores/react';
+import { memo, useCallback, useEffect, useState } from 'react';
+
+import { persistedStoreApi } from '@/renderer/services/store';
+
+export const SettingsModalCustomTorchIndexUrl = memo(() => {
+  const { customTorchIndexUrl } = useStore(persistedStoreApi.$atom);
+  // Keep a local value so typing doesn't round-trip to the store on every keystroke. We persist on blur.
+  const [value, setValue] = useState(customTorchIndexUrl ?? '');
+
+  useEffect(() => {
+    setValue(customTorchIndexUrl ?? '');
+  }, [customTorchIndexUrl]);
+
+  const onChange = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
+    setValue(e.target.value);
+  }, []);
+
+  const onBlur = useCallback(() => {
+    const trimmed = value.trim();
+    persistedStoreApi.setKey('customTorchIndexUrl', trimmed === '' ? undefined : trimmed);
+  }, [value]);
+
+  return (
+    <FormControl orientation="vertical">
+      <Flex w="full" alignItems="center" justifyContent="space-between">
+        <FormLabel>Custom PyTorch Index URL</FormLabel>
+      </Flex>
+      <Input value={value} onChange={onChange} onBlur={onBlur} placeholder="https://download.pytorch.org/whl/cu126" />
+      <FormHelperText>
+        Advanced: overrides the PyTorch index URL from Invoke&apos;s pins for all installs and updates. Use this if the
+        default build does not support your GPU (e.g. older Nvidia cards) or for AMD on Windows, where no index is
+        provided. The torch version is still pinned by Invoke &ndash; this only changes the build/index. If you set
+        this, you are on your own: an invalid URL will break installation. Leave empty to use Invoke&apos;s default.
+      </FormHelperText>
+    </FormControl>
+  );
+});
+SettingsModalCustomTorchIndexUrl.displayName = 'SettingsModalCustomTorchIndexUrl';

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -52,6 +52,15 @@ export type StoreData = {
   launcherWindowProps?: WindowProps;
   appWindowProps?: WindowProps;
   optInToLauncherPrereleases: boolean;
+  /**
+   * An optional user-provided PyTorch index URL. When set, it overrides the index URL derived from Invoke's pins for
+   * all installs and updates.
+   *
+   * This is an advanced escape hatch for cases the pins can't cover, e.g. older Nvidia GPUs that need a different CUDA
+   * build, or AMD on Windows (where the pins provide no index at all). Note that this only changes the index/build - the
+   * torch *version* is still pinned by the invokeai package.
+   */
+  customTorchIndexUrl?: string;
 };
 
 // The electron store uses JSON schema to validate its data.
@@ -96,6 +105,9 @@ export const schema: Schema<StoreData> = {
   optInToLauncherPrereleases: {
     type: 'boolean',
     default: false,
+  },
+  customTorchIndexUrl: {
+    type: 'string',
   },
 };
 


### PR DESCRIPTION
## Why

The launcher derives the PyTorch index URL from InvokeAI's `pins.json`. That file exposes only a single `cuda` (and `rocm`/`cpu`) entry per platform, so every Nvidia GPU tier collapses onto the same index (currently `cu128`). This causes two real problems the pins can't cover:

- **Older Nvidia GPUs (e.g. 20xx):** the pinned `cu128` build doesn't work for them, so users have to manually reinstall a compatible torch build **after every update** — the launcher overwrites it each time with `--force-reinstall`.
- **AMD on Windows:** `pins.json` provides **no** `rocm` index for `win32`, so the installer silently falls back to the default PyPI index and installs a non-working (CUDA/CPU) build. There is no official ROCm-on-Windows wheel index the launcher could ship as a default.

This PR adds an advanced **escape hatch**: a user-settable, persisted PyTorch index URL that overrides the pinned one for all installs and updates. The user takes responsibility for providing a working URL.

## What changed

- New **"Custom PyTorch Index URL"** setting in the Settings modal, persisted in the electron-store (`customTorchIndexUrl`). Empty = use Invoke's default (unchanged behavior).
- `InstallManager` uses the override in place of the pins-derived index when set, and logs a clear notice when the override is active.
- The hint text makes the limitation explicit: this only changes the **index/build** — the torch **version** is still pinned by the `invokeai` package.

## How to test

1. Run the launcher in dev (`npm run dev`).
2. Open **Settings**. Confirm a new **"Custom PyTorch Index URL"** field appears with the warning hint.
3. **Persistence / clearing:**
   - Enter a value (e.g. `https://download.pytorch.org/whl/cu126`), click elsewhere to blur, close and reopen Settings → the value persists.
   - Clear the field and blur → it is removed
4. **Override is applied:** start an install/reinstall and watch the install log. With the field set you should see:
   - the magenta line `Custom torch index URL override is active (set in Settings): <url>`
   - the install command using `--index=<your-url>` instead of the pinned one.
5. **Default path unchanged:** clear the field, start an install again → the log shows the index from `pins.json` (e.g. `cu128`) and no override line.
6. **AMD on Windows gap:** select the AMD GPU type on Windows with the field empty → log shows `Using torch index: default` (the pre-existing gap). Set a working ROCm-Windows wheel index in the field → the install now uses it.