### PR TITLE
Use Invoke uv lock for bootstrap installs

### DIFF
--- a/src/main/install-manager.ts
+++ b/src/main/install-manager.ts
@@ -15,7 +15,7 @@ import { SimpleLogger } from '@/lib/simple-logger';
 import { FIRST_RUN_MARKER_FILENAME } from '@/main/constants';
 import { getInstallationDetails, getTorchPlatform, getUVExecutablePath, isDirectory, isFile } from '@/main/util';
 import type { InvokeReleaseInstallFiles } from '@/shared/pins';
-import { getInvokeReleaseInstallFiles, getInvokeReleaseTag, getPins } from '@/shared/pins';
+import { getInvokeReleaseInstallFiles, getPins } from '@/shared/pins';
 import type {
   GpuType,
   InstallProcessStatus,
@@ -26,16 +26,16 @@ import type {
 } from '@/shared/types';
 
 const BOOTSTRAP_PROJECT_DIR_NAME = '.launcher-bootstrap';
-const MIN_BOOTSTRAP_INSTALL_VERSION = '6.14.0';
+const MIN_BOOTSTRAP_INSTALL_VERSION = '6.14.0rc1';
 
 const shouldUseBootstrapInstall = (version: string): boolean => {
   return compare(version.replace(/^v/, ''), MIN_BOOTSTRAP_INSTALL_VERSION) >= 0;
 };
 
-const getInvokeExtras = (gpuType: GpuType, torchPlatform: 'cuda' | 'rocm' | 'cpu'): string[] => {
+const getInvokeExtras = (gpuType: GpuType, torchPlatform: 'cuda' | 'rocm' | 'cpu' | null): string[] => {
   const extras: string[] = [];
 
-  if (process.platform !== 'darwin') {
+  if (torchPlatform && process.platform !== 'darwin') {
     extras.push(torchPlatform);
   }
 
@@ -50,6 +50,20 @@ const getInvokeExtras = (gpuType: GpuType, torchPlatform: 'cuda' | 'rocm' | 'cpu
 const getInvokePackageSpecifier = (version: string, extras: string[]): string => {
   const extrasSpecifier = extras.length > 0 ? `[${extras.join(',')}]` : '';
   return `invokeai${extrasSpecifier}==${version}`;
+};
+
+const getDeclaredOptionalDependencies = (pyprojectToml: string): Set<string> => {
+  const match = pyprojectToml.match(/\n\[project\.optional-dependencies\]\s*([\s\S]*?)(?=\n\[|\n#===|$)/);
+  const optionalDependencies = match?.[1];
+  if (!optionalDependencies) {
+    return new Set();
+  }
+
+  return new Set(
+    [...optionalDependencies.matchAll(/^"?([\w-]+)"?\s*=/gm)]
+      .map((extra) => extra[1])
+      .filter((extra): extra is string => Boolean(extra))
+  );
 };
 
 const writeBootstrapProject = async (arg: {
@@ -212,18 +226,15 @@ export class InstallManager {
     // The torch platform is determined by the GPU type, which in turn determines which torch extra and index to use
     const torchPlatform = getTorchPlatform(gpuType);
     const useBootstrapInstall = shouldUseBootstrapInstall(version);
-    const invokeExtras = useBootstrapInstall ? getInvokeExtras(gpuType, torchPlatform) : [];
-    if (!useBootstrapInstall && gpuType === 'nvidia<30xx') {
-      invokeExtras.push('xformers');
-    }
-    const invokeaiPackageSpecifier = getInvokePackageSpecifier(version, invokeExtras);
+    let invokeExtras = getInvokeExtras(gpuType, useBootstrapInstall ? torchPlatform : null);
 
     const bootstrapProjectPath = path.resolve(path.join(location, BOOTSTRAP_PROJECT_DIR_NAME));
     await fs.rm(bootstrapProjectPath, { recursive: true, force: true }).catch(() => {
       this.log.warn(c.yellow('Failed to delete previous bootstrap project\r\n'));
     });
 
-    let releaseFiles: InvokeReleaseInstallFiles;
+    let releaseFiles: InvokeReleaseInstallFiles | null = null;
+    let pins: Awaited<ReturnType<typeof getPins>>;
 
     if (useBootstrapInstall) {
       // Get the selected Invoke release's install metadata. For Invoke 6.14.0+, the bootstrap project uses the release
@@ -246,6 +257,14 @@ export class InstallManager {
       }
 
       releaseFiles = releaseFilesResult.value;
+      pins = releaseFiles.pins;
+      const declaredExtras = getDeclaredOptionalDependencies(releaseFiles.pyprojectToml);
+      const omittedExtras = invokeExtras.filter((extra) => !declaredExtras.has(extra));
+      invokeExtras = invokeExtras.filter((extra) => declaredExtras.has(extra));
+
+      if (omittedExtras.length > 0) {
+        this.log.warn(c.yellow(`Skipping undefined Invoke package extras: ${omittedExtras.join(', ')}\r\n`));
+      }
     } else {
       const pinsResult = await withResultAsync(() => getPins(version));
 
@@ -261,15 +280,11 @@ export class InstallManager {
         return;
       }
 
-      releaseFiles = {
-        tag: getInvokeReleaseTag(version),
-        pins: pinsResult.value,
-        pyprojectToml: '',
-        uvLock: '',
-      };
+      pins = pinsResult.value;
     }
 
-    const pythonVersion = releaseFiles.pins.python;
+    const invokeaiPackageSpecifier = getInvokePackageSpecifier(version, invokeExtras);
+    const pythonVersion = pins.python;
 
     const installationDetails = await getInstallationDetails(location);
 
@@ -473,6 +488,8 @@ export class InstallManager {
     let installInvokeArgs: string[];
 
     if (useBootstrapInstall) {
+      assert(releaseFiles, 'Bootstrap install requires release files');
+
       const bootstrapProjectResult = await withResultAsync(() =>
         writeBootstrapProject({
           location,
@@ -562,6 +579,7 @@ export class InstallManager {
         '--python-preference',
         'only-managed',
         '--no-deps',
+        '--force-reinstall',
         '--compile-bytecode',
         `${invokeaiPackageSpecifier}`,
       ];
@@ -584,7 +602,7 @@ export class InstallManager {
         '--compile-bytecode',
       ];
 
-      const torchIndexUrl = releaseFiles.pins.torchIndexUrl[systemPlatform][torchPlatform];
+      const torchIndexUrl = pins.torchIndexUrl[systemPlatform][torchPlatform];
       if (torchIndexUrl) {
         installInvokeArgs.push(`--index=${torchIndexUrl}`);
       }

--- a/src/main/install-manager.ts
+++ b/src/main/install-manager.ts
@@ -1,5 +1,5 @@
 import type { IpcListener } from '@electron-toolkit/typed-ipc/main';
-import { major, minor } from '@renovatebot/pep440';
+import { compare, major, minor } from '@renovatebot/pep440';
 import c from 'ansi-colors';
 import { ipcMain } from 'electron';
 import fs from 'fs/promises';
@@ -14,7 +14,8 @@ import { withResultAsync } from '@/lib/result';
 import { SimpleLogger } from '@/lib/simple-logger';
 import { FIRST_RUN_MARKER_FILENAME } from '@/main/constants';
 import { getInstallationDetails, getTorchPlatform, getUVExecutablePath, isDirectory, isFile } from '@/main/util';
-import { getPins } from '@/shared/pins';
+import type { InvokeReleaseInstallFiles } from '@/shared/pins';
+import { getInvokeReleaseInstallFiles, getInvokeReleaseTag, getPins } from '@/shared/pins';
 import type {
   GpuType,
   InstallProcessStatus,
@@ -23,6 +24,49 @@ import type {
   LogEntry,
   WithTimestamp,
 } from '@/shared/types';
+
+const BOOTSTRAP_PROJECT_DIR_NAME = '.launcher-bootstrap';
+const MIN_BOOTSTRAP_INSTALL_VERSION = '6.14.0';
+
+const shouldUseBootstrapInstall = (version: string): boolean => {
+  return compare(version.replace(/^v/, ''), MIN_BOOTSTRAP_INSTALL_VERSION) >= 0;
+};
+
+const getInvokeExtras = (gpuType: GpuType, torchPlatform: 'cuda' | 'rocm' | 'cpu'): string[] => {
+  const extras: string[] = [];
+
+  if (process.platform !== 'darwin') {
+    extras.push(torchPlatform);
+  }
+
+  // We only install xformers on 20xx and earlier Nvidia GPUs - otherwise, torch's native sdp is faster
+  if (gpuType === 'nvidia<30xx') {
+    extras.push('xformers');
+  }
+
+  return extras;
+};
+
+const getInvokePackageSpecifier = (version: string, extras: string[]): string => {
+  const extrasSpecifier = extras.length > 0 ? `[${extras.join(',')}]` : '';
+  return `invokeai${extrasSpecifier}==${version}`;
+};
+
+const writeBootstrapProject = async (arg: {
+  location: string;
+  releaseFiles: InvokeReleaseInstallFiles;
+}): Promise<string> => {
+  const bootstrapProjectPath = path.resolve(path.join(arg.location, BOOTSTRAP_PROJECT_DIR_NAME));
+  await fs.rm(bootstrapProjectPath, { recursive: true, force: true });
+  await fs.mkdir(bootstrapProjectPath, { recursive: true });
+
+  await Promise.all([
+    fs.writeFile(path.join(bootstrapProjectPath, 'pyproject.toml'), arg.releaseFiles.pyprojectToml),
+    fs.writeFile(path.join(bootstrapProjectPath, 'uv.lock'), arg.releaseFiles.uvLock),
+  ]);
+
+  return bootstrapProjectPath;
+};
 
 export class InstallManager {
   private status: WithTimestamp<InstallProcessStatus>;
@@ -130,7 +174,7 @@ export class InstallManager {
     /**
      * Installation is a 2-step process:
      * - Create a virtual environment.
-     * - Install the invokeai package.
+     * - Generate a bootstrap project from the selected Invoke release and sync it into the virtual environment.
      *
      * If repair mode is enabled, we do these additional steps before the above:
      * - Forcibly reinstall the uv-managed python.
@@ -165,30 +209,67 @@ export class InstallManager {
       `Unsupported platform: ${systemPlatform} ${systemArch}`
     );
 
-    // The torch platform is determined by the GPU type, which in turn determines which pypi index to use
+    // The torch platform is determined by the GPU type, which in turn determines which torch extra and index to use
     const torchPlatform = getTorchPlatform(gpuType);
+    const useBootstrapInstall = shouldUseBootstrapInstall(version);
+    const invokeExtras = useBootstrapInstall ? getInvokeExtras(gpuType, torchPlatform) : [];
+    if (!useBootstrapInstall && gpuType === 'nvidia<30xx') {
+      invokeExtras.push('xformers');
+    }
+    const invokeaiPackageSpecifier = getInvokePackageSpecifier(version, invokeExtras);
 
-    // We only install xformers on 20xx and earlier Nvidia GPUs - otherwise, torch's native sdp is faster
-    const withXformers = gpuType === 'nvidia<30xx';
-    const invokeaiPackageSpecifier = withXformers ? 'invokeai[xformers]' : 'invokeai';
+    const bootstrapProjectPath = path.resolve(path.join(location, BOOTSTRAP_PROJECT_DIR_NAME));
+    await fs.rm(bootstrapProjectPath, { recursive: true, force: true }).catch(() => {
+      this.log.warn(c.yellow('Failed to delete previous bootstrap project\r\n'));
+    });
 
-    // Get the Python version and torch index URL for the target version
-    const pinsResult = await withResultAsync(() => getPins(version));
+    let releaseFiles: InvokeReleaseInstallFiles;
 
-    if (pinsResult.isErr()) {
-      this.log.error(`Failed to get pins for version ${version}: ${pinsResult.error.message}\r\n`);
-      this.updateStatus({
-        type: 'error',
-        error: {
-          message: 'Failed to get pins',
-          context: serializeError(pinsResult.error),
-        },
-      });
-      return;
+    if (useBootstrapInstall) {
+      // Get the selected Invoke release's install metadata. For Invoke 6.14.0+, the bootstrap project uses the release
+      // pyproject.toml and lockfile to sync dependencies, then installs the published invokeai package for the selected
+      // version. Older versions use the legacy pip install path.
+      const releaseFilesResult = await withResultAsync(() => getInvokeReleaseInstallFiles(version));
+
+      if (releaseFilesResult.isErr()) {
+        this.log.error(
+          `Failed to get Invoke release install files for version ${version}: ${releaseFilesResult.error.message}\r\n`
+        );
+        this.updateStatus({
+          type: 'error',
+          error: {
+            message: 'Failed to get Invoke release install files',
+            context: serializeError(releaseFilesResult.error),
+          },
+        });
+        return;
+      }
+
+      releaseFiles = releaseFilesResult.value;
+    } else {
+      const pinsResult = await withResultAsync(() => getPins(version));
+
+      if (pinsResult.isErr()) {
+        this.log.error(`Failed to get pins for version ${version}: ${pinsResult.error.message}\r\n`);
+        this.updateStatus({
+          type: 'error',
+          error: {
+            message: 'Failed to get pins',
+            context: serializeError(pinsResult.error),
+          },
+        });
+        return;
+      }
+
+      releaseFiles = {
+        tag: getInvokeReleaseTag(version),
+        pins: pinsResult.value,
+        pyprojectToml: '',
+        uvLock: '',
+      };
     }
 
-    const pythonVersion = pinsResult.value.python;
-    const torchIndexUrl = pinsResult.value.torchIndexUrl[systemPlatform][torchPlatform];
+    const pythonVersion = releaseFiles.pins.python;
 
     const installationDetails = await getInstallationDetails(location);
 
@@ -217,7 +298,12 @@ export class InstallManager {
     this.log.info(`- Python version: ${pythonVersion}\r\n`);
     this.log.info(`- GPU type: ${gpuType}\r\n`);
     this.log.info(`- Torch platform: ${torchPlatform}\r\n`);
-    this.log.info(`- Using torch index: ${torchIndexUrl ?? 'default'}\r\n`);
+    this.log.info(`- Invoke package: ${invokeaiPackageSpecifier}\r\n`);
+    this.log.info(
+      `- Dependency resolution: ${
+        useBootstrapInstall ? 'frozen Invoke pyproject.toml and uv.lock' : 'legacy package metadata install'
+      }\r\n`
+    );
 
     if (repair) {
       this.log.info(c.magenta('Repair mode enabled:\r\n'));
@@ -381,34 +467,131 @@ export class InstallManager {
       return;
     }
 
-    // Install the invokeai package
-    const installInvokeArgs = [
-      // Use `uv`s pip interface to install the invokeai package
-      'pip',
-      'install',
-      // Ensure we install against the correct python version
-      '--python',
-      pythonVersion,
-      // Always use a managed python version - never the system python
-      '--python-preference',
-      'only-managed',
-      `${invokeaiPackageSpecifier}==${version}`,
-      // This may be unnecessary with `uv`, but we've had issues where `pip` screws up dependencies without --force-reinstall
-      '--force-reinstall',
-      // TODO(psyche): Last time I checked, this didn't seem to work - the bytecode wasn't compiled
-      '--compile-bytecode',
-    ];
-
-    if (torchIndexUrl) {
-      installInvokeArgs.push(`--index=${torchIndexUrl}`);
-    }
-
     // Manually set the VIRTUAL_ENV environment variable to the venv path to ensure `uv` uses it correctly.
-    // Unfortunately there is no way to specify this in the `uv` CLI.
     runProcessOptions.env.VIRTUAL_ENV = venvPath;
 
+    let installInvokeArgs: string[];
+
+    if (useBootstrapInstall) {
+      const bootstrapProjectResult = await withResultAsync(() =>
+        writeBootstrapProject({
+          location,
+          releaseFiles,
+        })
+      );
+
+      if (bootstrapProjectResult.isErr()) {
+        this.log.error(c.red(`Failed to create bootstrap project: ${bootstrapProjectResult.error.message}\r\n`));
+        this.updateStatus({
+          type: 'error',
+          error: {
+            message: 'Failed to create bootstrap project',
+            context: serializeError(bootstrapProjectResult.error),
+          },
+        });
+        return;
+      }
+
+      const bootstrapProjectPath = bootstrapProjectResult.value;
+      const syncInvokeArgs = [
+        // Use `uv sync` against the selected Invoke release's pyproject.toml and lockfile.
+        'sync',
+        '--project',
+        bootstrapProjectPath,
+        // The generated project is only a dependency resolver. Do not install it into the app venv.
+        '--no-install-project',
+        // Sync into the venv we created above, rather than creating a venv under the bootstrap project.
+        '--active',
+        // Do not remove user-installed packages from the app venv.
+        '--inexact',
+        // The selected Invoke release's uv.lock should be authoritative.
+        '--frozen',
+        // Ensure we sync against the correct python version.
+        '--python',
+        pythonVersion,
+        // Always use a managed python version - never the system python.
+        '--python-preference',
+        'only-managed',
+        '--compile-bytecode',
+      ];
+
+      for (const extra of invokeExtras) {
+        syncInvokeArgs.push('--extra', extra);
+      }
+
+      this.log.info(c.cyan('Syncing invokeai environment...\r\n'));
+      this.log.info(`> VIRTUAL_ENV=${venvPath} ${uvPath} ${syncInvokeArgs.join(' ')}\r\n`);
+
+      const syncEnvResult = await withResultAsync(() =>
+        this.runCommand(uvPath, syncInvokeArgs, { ...runProcessOptions, cwd: bootstrapProjectPath })
+      );
+
+      if (syncEnvResult.isErr()) {
+        this.log.error(c.red(`Failed to sync invokeai environment: ${syncEnvResult.error.message}\r\n`));
+        this.logRepairModeMessages();
+        this.updateStatus({
+          type: 'error',
+          error: {
+            message: 'Failed to sync invokeai environment',
+            context: serializeError(syncEnvResult.error),
+          },
+        });
+        return;
+      }
+
+      if (syncEnvResult.value === 'canceled') {
+        this.log.warn(c.yellow('Installation canceled\r\n'));
+        this.updateStatus({ type: 'canceled' });
+        return;
+      }
+
+      // Check for cancellation before proceeding to package installation
+      if (this.isCancellationRequested) {
+        this.log.warn(c.yellow('Installation canceled\r\n'));
+        this.updateStatus({ type: 'canceled' });
+        return;
+      }
+
+      installInvokeArgs = [
+        // Install the published Invoke package after syncing its locked dependencies. Dependencies are installed by
+        // `uv sync` above, so do not resolve them again from wheel metadata.
+        'pip',
+        'install',
+        '--python',
+        venvPath,
+        '--python-preference',
+        'only-managed',
+        '--no-deps',
+        '--compile-bytecode',
+        `${invokeaiPackageSpecifier}`,
+      ];
+    } else {
+      installInvokeArgs = [
+        // Use `uv`s pip interface to install the invokeai package
+        'pip',
+        'install',
+        // Ensure we install against the correct python version
+        '--python',
+        pythonVersion,
+        // Always use a managed python version - never the system python
+        '--python-preference',
+        'only-managed',
+        `${invokeaiPackageSpecifier}`,
+        // This may be unnecessary with `uv`, but we've had issues where `pip` screws up dependencies without
+        // --force-reinstall
+        '--force-reinstall',
+        // TODO(psyche): Last time I checked, this didn't seem to work - the bytecode wasn't compiled
+        '--compile-bytecode',
+      ];
+
+      const torchIndexUrl = releaseFiles.pins.torchIndexUrl[systemPlatform][torchPlatform];
+      if (torchIndexUrl) {
+        installInvokeArgs.push(`--index=${torchIndexUrl}`);
+      }
+    }
+
     this.log.info(c.cyan('Installing invokeai package...\r\n'));
-    this.log.info(`> ${uvPath} ${installInvokeArgs.join(' ')}\r\n`);
+    this.log.info(`> VIRTUAL_ENV=${venvPath} ${uvPath} ${installInvokeArgs.join(' ')}\r\n`);
 
     const installAppResult = await withResultAsync(() =>
       this.runCommand(uvPath, installInvokeArgs, { ...runProcessOptions, cwd: location })

--- a/src/shared/pins.test.ts
+++ b/src/shared/pins.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
-import { getInvokeReleaseInstallFiles, getInvokeReleaseTag, getPins } from './pins';
+import { getInvokeReleaseInstallFiles, getPins } from './pins';
 
 const pins = {
   python: '3.12',
@@ -22,11 +22,6 @@ describe('pins', () => {
     vi.unstubAllGlobals();
   });
 
-  it('normalizes invoke release tags', () => {
-    expect(getInvokeReleaseTag('6.14.0')).toBe('v6.14.0');
-    expect(getInvokeReleaseTag('v6.14.0')).toBe('v6.14.0');
-  });
-
   it('fetches install files from the selected invoke release', async () => {
     const fetchMock = vi.fn((url: string) => {
       if (url.endsWith('/pins.json')) {
@@ -45,7 +40,6 @@ describe('pins', () => {
     const files = await getInvokeReleaseInstallFiles('6.14.0');
 
     expect(files).toEqual({
-      tag: 'v6.14.0',
       pins,
       pyprojectToml: '[project]\nname = "InvokeAI"\n',
       uvLock: 'version = 1\n',

--- a/src/shared/pins.test.ts
+++ b/src/shared/pins.test.ts
@@ -1,0 +1,73 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { getInvokeReleaseInstallFiles, getInvokeReleaseTag, getPins } from './pins';
+
+const pins = {
+  python: '3.12',
+  torchIndexUrl: {
+    win32: {
+      cuda: 'https://download.pytorch.org/whl/cu128',
+    },
+    linux: {
+      cpu: 'https://download.pytorch.org/whl/cpu',
+      rocm: 'https://download.pytorch.org/whl/rocm7.1',
+      cuda: 'https://download.pytorch.org/whl/cu128',
+    },
+    darwin: {},
+  },
+};
+
+describe('pins', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('normalizes invoke release tags', () => {
+    expect(getInvokeReleaseTag('6.14.0')).toBe('v6.14.0');
+    expect(getInvokeReleaseTag('v6.14.0')).toBe('v6.14.0');
+  });
+
+  it('fetches install files from the selected invoke release', async () => {
+    const fetchMock = vi.fn((url: string) => {
+      if (url.endsWith('/pins.json')) {
+        return new Response(JSON.stringify(pins));
+      }
+      if (url.endsWith('/pyproject.toml')) {
+        return new Response('[project]\nname = "InvokeAI"\n');
+      }
+      if (url.endsWith('/uv.lock')) {
+        return new Response('version = 1\n');
+      }
+      return new Response('', { status: 404 });
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const files = await getInvokeReleaseInstallFiles('6.14.0');
+
+    expect(files).toEqual({
+      tag: 'v6.14.0',
+      pins,
+      pyprojectToml: '[project]\nname = "InvokeAI"\n',
+      uvLock: 'version = 1\n',
+    });
+    expect(fetchMock).toHaveBeenCalledWith('https://raw.githubusercontent.com/invoke-ai/InvokeAI/v6.14.0/pins.json');
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://raw.githubusercontent.com/invoke-ai/InvokeAI/v6.14.0/pyproject.toml'
+    );
+    expect(fetchMock).toHaveBeenCalledWith('https://raw.githubusercontent.com/invoke-ai/InvokeAI/v6.14.0/uv.lock');
+  });
+
+  it('falls back to jsdelivr when fetching legacy pins', async () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(new Response('', { status: 404 }))
+      .mockResolvedValueOnce(new Response(JSON.stringify(pins)));
+    vi.stubGlobal('fetch', fetchMock);
+
+    await expect(getPins('6.13.0')).resolves.toEqual(pins);
+    expect(fetchMock).toHaveBeenCalledWith('https://raw.githubusercontent.com/invoke-ai/InvokeAI/v6.13.0/pins.json');
+    expect(fetchMock).toHaveBeenCalledWith('https://cdn.jsdelivr.net/gh/invoke-ai/InvokeAI@v6.13.0/pins.json');
+    expect(warnSpy).toHaveBeenCalledOnce();
+  });
+});

--- a/src/shared/pins.ts
+++ b/src/shared/pins.ts
@@ -13,10 +13,10 @@ const zPins = z.object({
    */
   python: z.string(),
   /**
-   * The index urls for the torch package for the given version of the invokeai package for each platform.
+   * Legacy index urls for the torch package for the given version of the invokeai package for each platform.
    *
-   * The pytorch project changes these urls frequently, so we need to pin them to ensure that the correct version
-   * is installed, else you can end up with CPU torch on a GPU machine or vice versa.
+   * These are retained for compatibility with the current pins.json shape. The installer syncs dependencies from the
+   * selected Invoke release's pyproject.toml and uv.lock; these URLs are not used as dependency resolution authority.
    *
    * Each platform has a set of indices for each torch device.
    *
@@ -30,8 +30,37 @@ const zPins = z.object({
 });
 type Pins = z.infer<typeof zPins>;
 
+export type InvokeReleaseInstallFiles = {
+  tag: string;
+  pins: Pins;
+  pyprojectToml: string;
+  uvLock: string;
+};
+
+export const getInvokeReleaseTag = (targetVersion: string): string => {
+  return targetVersion.startsWith('v') ? targetVersion : `v${targetVersion}`;
+};
+
+const fetchInvokeReleaseFile = async (tag: string, filePath: string): Promise<string> => {
+  for (const url of [
+    `https://raw.githubusercontent.com/invoke-ai/InvokeAI/${tag}/${filePath}`,
+    `https://cdn.jsdelivr.net/gh/invoke-ai/InvokeAI@${tag}/${filePath}`,
+  ]) {
+    console.log(`Fetching ${filePath} from ${url}`);
+    try {
+      const res = await fetch(url);
+      assert(res.ok, 'Network error');
+      return await res.text();
+    } catch (err) {
+      console.warn(`Failed to fetch ${filePath}`, err);
+    }
+  }
+
+  throw new Error(`Failed to fetch ${filePath}`);
+};
+
 /**
- * Fetch the python version and PyTorch version pins required to install the target version.
+ * Fetch the bootstrap pins required to install the target version.
  *
  * The pins are fetched from the GitHub repo.
  *
@@ -40,11 +69,11 @@ type Pins = z.infer<typeof zPins>;
  * update the launcher whenever the app's PyTorch dependency or target python version changed.
  *
  * @param targetVersion - The version of the invokeai package
- * @returns The python version and torch index urls
+ * @returns Launcher bootstrap metadata. Dependency resolution is handled by the fetched pyproject.toml and uv.lock.
  * @throws If no pins are found for the given version
  */
 export const getPins = async (targetVersion: string): Promise<Pins> => {
-  const tag = targetVersion.startsWith('v') ? targetVersion : `v${targetVersion}`;
+  const tag = getInvokeReleaseTag(targetVersion);
 
   for (const url of [
     `https://raw.githubusercontent.com/invoke-ai/InvokeAI/${tag}/pins.json`,
@@ -63,4 +92,20 @@ export const getPins = async (targetVersion: string): Promise<Pins> => {
   }
 
   throw new Error('Failed to fetch pins');
+};
+
+export const getInvokeReleaseInstallFiles = async (targetVersion: string): Promise<InvokeReleaseInstallFiles> => {
+  const tag = getInvokeReleaseTag(targetVersion);
+  const [pinsJson, pyprojectToml, uvLock] = await Promise.all([
+    fetchInvokeReleaseFile(tag, 'pins.json'),
+    fetchInvokeReleaseFile(tag, 'pyproject.toml'),
+    fetchInvokeReleaseFile(tag, 'uv.lock'),
+  ]);
+
+  return {
+    tag,
+    pins: zPins.parse(JSON.parse(pinsJson)),
+    pyprojectToml,
+    uvLock,
+  };
 };

--- a/src/shared/pins.ts
+++ b/src/shared/pins.ts
@@ -31,13 +31,12 @@ const zPins = z.object({
 type Pins = z.infer<typeof zPins>;
 
 export type InvokeReleaseInstallFiles = {
-  tag: string;
   pins: Pins;
   pyprojectToml: string;
   uvLock: string;
 };
 
-export const getInvokeReleaseTag = (targetVersion: string): string => {
+const getInvokeReleaseTag = (targetVersion: string): string => {
   return targetVersion.startsWith('v') ? targetVersion : `v${targetVersion}`;
 };
 
@@ -74,24 +73,7 @@ const fetchInvokeReleaseFile = async (tag: string, filePath: string): Promise<st
  */
 export const getPins = async (targetVersion: string): Promise<Pins> => {
   const tag = getInvokeReleaseTag(targetVersion);
-
-  for (const url of [
-    `https://raw.githubusercontent.com/invoke-ai/InvokeAI/${tag}/pins.json`,
-    `https://cdn.jsdelivr.net/gh/invoke-ai/InvokeAI@${tag}/pins.json`,
-  ]) {
-    console.log(`Fetching pins from ${url}`);
-    try {
-      const res = await fetch(url);
-      assert(res.ok, 'Network error');
-      const json = await res.json();
-      const pins = zPins.parse(json);
-      return pins;
-    } catch (err) {
-      console.warn('Failed to fetch pins', err);
-    }
-  }
-
-  throw new Error('Failed to fetch pins');
+  return zPins.parse(JSON.parse(await fetchInvokeReleaseFile(tag, 'pins.json')));
 };
 
 export const getInvokeReleaseInstallFiles = async (targetVersion: string): Promise<InvokeReleaseInstallFiles> => {
@@ -103,7 +85,6 @@ export const getInvokeReleaseInstallFiles = async (targetVersion: string): Promi
   ]);
 
   return {
-    tag,
     pins: zPins.parse(JSON.parse(pinsJson)),
     pyprojectToml,
     uvLock,


### PR DESCRIPTION
## Motivation

The launcher currently installs Invoke with `uv pip install invokeai==<version>` and uses `pins.json` to choose Python and Torch indexes. That means launcher installs do not fully follow the dependency resolution used by Invoke's `uv sync` workflow - plus, the invoke `pins.json` file must be kept updated (spoiler: it is out of date as of 6.13.x).

This change makes launcher installs for Invoke 6.14.0 and newer use the selected Invoke release's own `pyproject.toml` and `uv.lock` for dependency resolution. The launcher still installs the published Invoke package, so users do not need to build Invoke from source or build the frontend locally.

## Overview

For Invoke 6.14.0 and newer:

- Fetch `pins.json`, `pyproject.toml`, and `uv.lock` from the selected Invoke tag.
- Delete any previous `.launcher-bootstrap` directory at the start of an install attempt.
- Recreate `.launcher-bootstrap` inside the install directory with the fetched `pyproject.toml` and `uv.lock`.
- Run `uv sync --frozen --inexact --no-install-project --active` against that bootstrap project.
- Install the published `invokeai` package afterward with `uv pip install --no-deps`.

For Invoke versions older than 6.14.0:

- Keep the legacy install path.
- Use `pins.json` and `uv pip install`.
- Preserve the old `xformers` behavior for older NVIDIA GPUs.

`pins.json` is still used for the launcher Python version. Its Torch index fields are now legacy compatibility data for the new install path; dependency resolution for 6.14.0+ comes from `pyproject.toml` and `uv.lock`.

Changed files:

- `src/main/install-manager.ts`
- `src/shared/pins.ts`
- `src/shared/pins.test.ts`

## Tests

Ran:

```bash
npm run lint:tsc --prefix /tmp/invoke-launcher-src.pwDdIi/repo
npm run lint:eslint --prefix /tmp/invoke-launcher-src.pwDdIi/repo
npm run lint:prettier --prefix /tmp/invoke-launcher-src.pwDdIi/repo
npm run test:no-watch --prefix /tmp/invoke-launcher-src.pwDdIi/repo
```

The full test suite passes: 6 test files, 27 tests.

## Path Forward

The remaining reason to fetch `pins.json` in the new install path is the launcher Python version. To remove `pins.json`, Invoke should publish that launcher-specific Python version somewhere else.

A good option is to add a small launcher section to Invoke's `pyproject.toml`, for example:

```toml
[tool.invokeai.launcher]
python = "3.12"
```

Then the launcher could fetch only `pyproject.toml` and `uv.lock`, read the Python version from `pyproject.toml`, and reserve `pins.json` only as a legacy fallback for older Invoke versions.