### PR TITLE
docs: fix stale build/release instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ This project uses node 22 and npm as its package manager.
 Building the launcher is very simple:
 
 - `npm i`: install dependencies
-- `npm run app:dist`: build for your system's platform
+- `npm run package`: build for your system's platform
 
 As described in the next section, you do need to manually download the `uv` binary to get a functioning build.
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,8 +1,12 @@
 # Release
 
 1. Bump the version by running `npm run version [<newversion> | major | minor | patch | etc]`. PR & merge.
-2. Run `./scripts/tagRelease.sh` to create and push a new tag. This will trigger the `Build Signed Artifacts and Publish` workflow on GitHub.
-   - The workflow requires approval from @psychedelicious or @hipsterusername to run.
+   - For a prerelease, either pass the version explicitly (e.g. `npm run version 1.8.2-rc.1`) or let npm compute it: `npm run version prepatch --preid rc` bumps 1.8.1 to `1.8.2-rc.0`, and each subsequent `npm run version prerelease` increments to `-rc.1`, `-rc.2`, etc.
+   - To graduate a prerelease to the final release, use the increment level the prerelease was building toward: `npm run version patch` strips the suffix in place (`1.8.2-rc.1` → `1.8.2`). Likewise `minor` graduates `1.9.0-rc.1` → `1.9.0`. Careful with higher levels: `minor` from `1.8.2-rc.1` jumps to `1.9.0`, skipping `1.8.2` entirely.
+   - Omit the `v` prefix; `package.json` stores the bare version and the git tag gets the `v` added automatically.
+   - Note that pushing a prerelease tag triggers the signed-build workflow like any other `v*` tag.
+2. Run `./scripts/tagRelease.js` to create and push a new tag. This will trigger the `Build Signed Artifacts and Publish` workflow on GitHub.
+   - The workflow requires approval from a reviewer of the `code-signing` environment (currently @hipsterusername, @lstein, or @blessedcoolant) to run.
    - The workflow will create a draft release and upload signed artifacts to the draft. You do not need to upload anything else.
 3. Flesh out the GH release, following the format from prior releases.
 4. Post on Discord in the `releases` channel, and link to that post in the `new-release-discussion` channel.


### PR DESCRIPTION
## Summary

- **README**: `npm run app:dist` no longer exists (removed in the electron-vite/electron-builder migration, 93e14c4) — replaced with the current `npm run package`.
- **RELEASE**: the tag script is `scripts/tagRelease.js`, not `tagRelease.sh`.
- **RELEASE**: updated the signed-build approval note to reference the `code-signing` environment and its current required reviewers (@hipsterusername, @lstein, @blessedcoolant — verified via the GitHub API; @psychedelicious is no longer on the list).
- **RELEASE**: documented prerelease versioning under step 1: creating an rc (`npm run version prepatch --preid rc` or an explicit `1.8.2-rc.1`), iterating (`prerelease`), graduating to the final release (`patch` strips the suffix in place), that the `v` prefix should be omitted, and that pushing a prerelease tag triggers the signed-build workflow like any `v*` tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)