### PR TITLE
feat(install): GPU auto-detection + custom torch index override

### DIFF
--- a/src/main/gpu-detection.ts
+++ b/src/main/gpu-detection.ts
@@ -4,7 +4,7 @@ import os from 'node:os';
 import path from 'node:path';
 import { promisify } from 'node:util';
 
-import type { GpuBackend, GpuDetectionResult } from '@/shared/types';
+import type { GpuBackend, GpuConfidence, GpuDetectionResult, GpuVendor } from '@/shared/types';
 
 /**
  * Best-effort hardware probe for the compute backend (CUDA / ROCm / Metal / CPU). This is advisory only: the install
@@ -14,7 +14,7 @@ import type { GpuBackend, GpuDetectionResult } from '@/shared/types';
 
 const execFileAsync = promisify(execFile);
 
-type Confidence = 'high' | 'medium' | 'low' | 'weak-signal' | 'none';
+type Confidence = GpuConfidence;
 
 type ProbeResult = {
   ok: boolean;
@@ -154,7 +154,14 @@ async function hasNvidiaGpu(): Promise<BackendProbe> {
 }
 
 async function hasRocmGpu(): Promise<BackendProbe> {
-  const amdSmi = await runProbe('amd-smi', ['list']);
+  // Each external probe has a 3s timeout; running them sequentially would cost up to ~9s of spinner time on a machine
+  // without ROCm tools installed. They're independent, so run them concurrently and then evaluate in priority order.
+  const [amdSmi, rocmSmi, rocminfo] = await Promise.all([
+    runProbe('amd-smi', ['list']),
+    runProbe('rocm-smi', ['--showproductname']),
+    runProbe('rocminfo', []),
+  ]);
+
   if (
     amdSmi.ok &&
     /GPU:\s*\d+|ASIC|DEVICE/i.test(amdSmi.stdout) &&
@@ -163,12 +170,10 @@ async function hasRocmGpu(): Promise<BackendProbe> {
     return { detected: true, confidence: 'high', reason: '`amd-smi list` reported at least one AMD GPU' };
   }
 
-  const rocmSmi = await runProbe('rocm-smi', ['--showproductname']);
   if (rocmSmi.ok && rocmSmi.stdout.length > 0 && !/no devices|not found|failed/i.test(rocmSmi.stdout)) {
     return { detected: true, confidence: 'high', reason: '`rocm-smi --showproductname` returned GPU product output' };
   }
 
-  const rocminfo = await runProbe('rocminfo', []);
   const rocminfoHasGpuAgent =
     rocminfo.ok && /Device Type:\s+GPU/i.test(rocminfo.stdout) && /Name:\s+gfx[0-9a-f]+/i.test(rocminfo.stdout);
   if (rocminfoHasGpuAgent) {
@@ -215,13 +220,42 @@ async function hasMacGpuCapabilities(): Promise<BackendProbe> {
 }
 
 /**
+ * Detect a discrete AMD GPU on Windows. There is no supported ROCm-on-Windows install path, so this never yields a
+ * usable GPU backend - it exists purely so we can tell the user "we saw your AMD card, but Windows will use the CPU"
+ * instead of the misleading "no dedicated GPU detected". These are exactly the users the custom-index field targets.
+ */
+async function hasWindowsAmdGpu(): Promise<BackendProbe> {
+  if (process.platform !== 'win32') {
+    return { detected: false, confidence: 'none', reason: 'Not Windows' };
+  }
+
+  const videoControllers = await runProbe('powershell', [
+    '-NoProfile',
+    '-NonInteractive',
+    '-Command',
+    'Get-CimInstance Win32_VideoController | ForEach-Object { $_.Name }',
+  ]);
+
+  if (videoControllers.ok && /\b(AMD|Radeon|ATI)\b/i.test(videoControllers.stdout)) {
+    return { detected: true, confidence: 'medium', reason: 'Windows reported an AMD/Radeon display adapter' };
+  }
+
+  return { detected: false, confidence: 'none', reason: 'No AMD display adapter reported by Windows' };
+}
+
+/**
  * Detect the most likely compute backend for this machine. The result is advisory and always user-overridable.
  */
 export const detectGpu = async (): Promise<GpuDetectionResult> => {
-  const [nvidia, rocm, mac] = await Promise.all([hasNvidiaGpu(), hasRocmGpu(), hasMacGpuCapabilities()]);
+  const [nvidia, rocm, mac, windowsAmd] = await Promise.all([
+    hasNvidiaGpu(),
+    hasRocmGpu(),
+    hasMacGpuCapabilities(),
+    hasWindowsAmdGpu(),
+  ]);
 
   let backend: GpuBackend;
-  let vendor: string;
+  let vendor: GpuVendor;
   let confidence: Confidence;
   let decision: string;
 
@@ -240,10 +274,18 @@ export const detectGpu = async (): Promise<GpuDetectionResult> => {
     vendor = 'apple';
     confidence = mac.confidence;
     decision = mac.reason;
+  } else if (windowsAmd.detected) {
+    // A real AMD GPU, but no ROCm on Windows - the usable backend is still CPU. We surface the vendor so the UI can
+    // explain why, rather than claiming there's no GPU at all.
+    backend = 'cpu';
+    vendor = 'amd';
+    confidence = windowsAmd.confidence;
+    decision = 'AMD GPU detected on Windows, where ROCm is not supported - Invoke will use the CPU';
   } else {
     backend = 'cpu';
     vendor = 'cpu';
-    confidence = 'high';
+    // "No evidence found" is the opposite of high confidence - nothing was detected.
+    confidence = 'none';
     decision = 'No supported GPU backend detected';
   }
 

--- a/src/main/gpu-detection.ts
+++ b/src/main/gpu-detection.ts
@@ -1,0 +1,251 @@
+import { execFile } from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { promisify } from 'node:util';
+
+import type { GpuBackend, GpuDetectionResult } from '@/shared/types';
+
+/**
+ * Best-effort hardware probe for the compute backend (CUDA / ROCm / Metal / CPU). This is advisory only: the install
+ * flow presents the result to the user for confirmation and always allows a manual override, so a wrong guess is never
+ * fatal. Ported from a standalone prototype; probes are async so we never block the main process event loop.
+ */
+
+const execFileAsync = promisify(execFile);
+
+type Confidence = 'high' | 'medium' | 'low' | 'weak-signal' | 'none';
+
+type ProbeResult = {
+  ok: boolean;
+  command: string;
+  stdout: string;
+  stderr: string;
+  reason: string;
+};
+
+type BackendProbe = {
+  detected: boolean;
+  confidence: Confidence;
+  reason: string;
+};
+
+async function runProbe(command: string, args: string[] = []): Promise<ProbeResult> {
+  const commandLine = [command, ...args].join(' ');
+  try {
+    const { stdout } = await execFileAsync(command, args, { encoding: 'utf8', timeout: 3000 });
+    return { ok: true, command: commandLine, stdout: stdout.trim(), stderr: '', reason: 'command succeeded' };
+  } catch (error) {
+    const err = error as { stdout?: unknown; stderr?: unknown; message?: string };
+    return {
+      ok: false,
+      command: commandLine,
+      stdout: typeof err.stdout === 'string' ? err.stdout.trim() : '',
+      stderr: typeof err.stderr === 'string' ? err.stderr.trim() : '',
+      reason: err.message ?? 'command failed',
+    };
+  }
+}
+
+function fileExists(filePath: string): boolean {
+  return fs.existsSync(filePath);
+}
+
+function readFile(filePath: string): string {
+  try {
+    return fs.readFileSync(filePath, 'utf8').trim();
+  } catch {
+    return '';
+  }
+}
+
+function listDir(dirPath: string): string[] {
+  try {
+    return fs.readdirSync(dirPath);
+  } catch {
+    return [];
+  }
+}
+
+function parseKfdProperties(text: string): Record<string, string> {
+  const result: Record<string, string> = {};
+  for (const line of text.split(/\r?\n/)) {
+    const match = line.trim().match(/^([a-zA-Z0-9_]+)\s+(.+)$/);
+    if (match && match[1]) {
+      result[match[1]] = match[2] ?? '';
+    }
+  }
+  return result;
+}
+
+function numberValue(value: string | undefined): number {
+  if (value === undefined || value === '') {
+    return 0;
+  }
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : 0;
+}
+
+type KfdNode = { node: string; name: string; gpu_id: string; properties: string };
+
+function isUsableKfdGpuNode(node: KfdNode): boolean {
+  const props = parseKfdProperties(node.properties);
+  const name = node.name.trim();
+
+  const nameLooksLikeGpu = /^gfx[0-9a-f]+$/i.test(name);
+
+  const hasNonzeroGpuIdentity =
+    numberValue(props.gpu_id ?? node.gpu_id) > 0 ||
+    numberValue(props.vendor_id) > 0 ||
+    numberValue(props.device_id) > 0 ||
+    numberValue(props.location_id) > 0 ||
+    numberValue(props.drm_render_minor) > 0;
+
+  const hasComputeUnits =
+    numberValue(props.simd_count) > 0 && numberValue(props.array_count) > 0 && numberValue(props.cu_per_simd_array) > 0;
+
+  const hasGfxTarget = numberValue(props.gfx_target_version) > 0 || nameLooksLikeGpu;
+
+  return hasNonzeroGpuIdentity && hasComputeUnits && hasGfxTarget;
+}
+
+function probeKfdTopology(): { exists: boolean; hasUsableGpuNode: boolean } {
+  const base = '/sys/class/kfd/kfd/topology/nodes';
+  const nodes: KfdNode[] = listDir(base).map((nodeName) => {
+    const nodePath = path.join(base, nodeName);
+    return {
+      node: nodeName,
+      name: readFile(path.join(nodePath, 'name')),
+      gpu_id: readFile(path.join(nodePath, 'gpu_id')),
+      properties: readFile(path.join(nodePath, 'properties')),
+    };
+  });
+
+  return {
+    exists: fs.existsSync(base),
+    hasUsableGpuNode: nodes.some(isUsableKfdGpuNode),
+  };
+}
+
+function probeAmdRenderDevices(): { hasAmdRenderDevice: boolean } {
+  const drmPath = '/sys/class/drm';
+  const entries = listDir(drmPath).filter((name) => name.startsWith('renderD'));
+
+  const hasAmdRenderDevice = entries.some((entry) => {
+    const vendor = readFile(path.join(drmPath, entry, 'device', 'vendor'));
+    return vendor.toLowerCase() === '0x1002';
+  });
+
+  return { hasAmdRenderDevice };
+}
+
+async function hasNvidiaGpu(): Promise<BackendProbe> {
+  const nvidiaSmi = await runProbe('nvidia-smi', ['-L']);
+
+  if (nvidiaSmi.ok && nvidiaSmi.stdout.includes('GPU')) {
+    return { detected: true, confidence: 'high', reason: '`nvidia-smi -L` reported at least one GPU' };
+  }
+
+  if (fileExists('/proc/driver/nvidia') || fileExists('/dev/nvidia0')) {
+    return { detected: true, confidence: 'medium', reason: 'NVIDIA Linux device files exist' };
+  }
+
+  return { detected: false, confidence: 'none', reason: 'No NVIDIA evidence found' };
+}
+
+async function hasRocmGpu(): Promise<BackendProbe> {
+  const amdSmi = await runProbe('amd-smi', ['list']);
+  if (
+    amdSmi.ok &&
+    /GPU:\s*\d+|ASIC|DEVICE/i.test(amdSmi.stdout) &&
+    !/no devices|not found|failed/i.test(amdSmi.stdout)
+  ) {
+    return { detected: true, confidence: 'high', reason: '`amd-smi list` reported at least one AMD GPU' };
+  }
+
+  const rocmSmi = await runProbe('rocm-smi', ['--showproductname']);
+  if (rocmSmi.ok && rocmSmi.stdout.length > 0 && !/no devices|not found|failed/i.test(rocmSmi.stdout)) {
+    return { detected: true, confidence: 'high', reason: '`rocm-smi --showproductname` returned GPU product output' };
+  }
+
+  const rocminfo = await runProbe('rocminfo', []);
+  const rocminfoHasGpuAgent =
+    rocminfo.ok && /Device Type:\s+GPU/i.test(rocminfo.stdout) && /Name:\s+gfx[0-9a-f]+/i.test(rocminfo.stdout);
+  if (rocminfoHasGpuAgent) {
+    return { detected: true, confidence: 'high', reason: '`rocminfo` reported a GPU agent with a gfx target' };
+  }
+
+  const kfdTopology = probeKfdTopology();
+  if (kfdTopology.hasUsableGpuNode) {
+    return { detected: true, confidence: 'medium', reason: 'KFD topology contains at least one usable GPU node' };
+  }
+
+  const renderDevices = probeAmdRenderDevices();
+  if (fileExists('/dev/kfd') || renderDevices.hasAmdRenderDevice || kfdTopology.exists) {
+    return {
+      detected: false,
+      confidence: 'weak-signal',
+      reason: 'AMD/KFD evidence exists, but no ROCm tool or KFD topology node confirmed a usable ROCm GPU',
+    };
+  }
+
+  return { detected: false, confidence: 'none', reason: 'No ROCm evidence found' };
+}
+
+async function hasMacGpuCapabilities(): Promise<BackendProbe> {
+  if (process.platform !== 'darwin') {
+    return { detected: false, confidence: 'none', reason: 'Not macOS' };
+  }
+
+  if (os.arch() === 'arm64') {
+    return { detected: true, confidence: 'high', reason: 'Apple Silicon Mac detected' };
+  }
+
+  const systemProfiler = await runProbe('system_profiler', ['SPDisplaysDataType']);
+  const markers = ['Metal', 'AMD', 'Apple'];
+  if (systemProfiler.ok && markers.some((marker) => systemProfiler.stdout.includes(marker))) {
+    return {
+      detected: true,
+      confidence: 'medium',
+      reason: '`system_profiler SPDisplaysDataType` showed Mac GPU capability markers',
+    };
+  }
+
+  return { detected: false, confidence: 'none', reason: 'No macOS GPU capability evidence found' };
+}
+
+/**
+ * Detect the most likely compute backend for this machine. The result is advisory and always user-overridable.
+ */
+export const detectGpu = async (): Promise<GpuDetectionResult> => {
+  const [nvidia, rocm, mac] = await Promise.all([hasNvidiaGpu(), hasRocmGpu(), hasMacGpuCapabilities()]);
+
+  let backend: GpuBackend;
+  let vendor: string;
+  let confidence: Confidence;
+  let decision: string;
+
+  if (nvidia.detected) {
+    backend = 'cuda';
+    vendor = 'nvidia';
+    confidence = nvidia.confidence;
+    decision = nvidia.reason;
+  } else if (rocm.detected) {
+    backend = 'rocm';
+    vendor = 'amd';
+    confidence = rocm.confidence;
+    decision = rocm.reason;
+  } else if (mac.detected) {
+    backend = 'metal';
+    vendor = 'apple';
+    confidence = mac.confidence;
+    decision = mac.reason;
+  } else {
+    backend = 'cpu';
+    vendor = 'cpu';
+    confidence = 'high';
+    decision = 'No supported GPU backend detected';
+  }
+
+  return { backend, vendor, confidence, decision };
+};

--- a/src/main/gpu-detection.ts
+++ b/src/main/gpu-detection.ts
@@ -1,20 +1,27 @@
+import type { ChildProcess } from 'node:child_process';
 import { execFile } from 'node:child_process';
-import fs from 'node:fs';
+import fs from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
-import { promisify } from 'node:util';
 
-import type { GpuBackend, GpuConfidence, GpuDetectionResult, GpuVendor } from '@/shared/types';
+import type { GpuConfidence, GpuDetectionResult } from '@/shared/types';
 
 /**
  * Best-effort hardware probe for the compute backend (CUDA / ROCm / Metal / CPU). This is advisory only: the install
  * flow presents the result to the user for confirmation and always allows a manual override, so a wrong guess is never
- * fatal. Ported from a standalone prototype; probes are async so we never block the main process event loop.
+ * fatal. Ported from a standalone prototype; every probe is async and deadline-bounded so we neither block the main
+ * process event loop nor leave the caller waiting on a wedged driver.
  */
 
-const execFileAsync = promisify(execFile);
-
-type Confidence = GpuConfidence;
+/** Per-probe budget. Each probe is independent and they all run concurrently, so this is not additive. */
+const PROBE_TIMEOUT_MS = 3000;
+/**
+ * Overall budget for the whole detection. `execFile`'s own timeout only *signals* the child - the callback still waits
+ * for it to exit, and a process stuck in an uninterruptible driver ioctl (a wedged `nvidia-smi` under Xid 79, or
+ * `powershell` against a corrupt WMI repository) never does. Without a hard deadline the IPC reply never arrives, the
+ * Configure step spins forever and its Next button can never enable.
+ */
+const DETECTION_TIMEOUT_MS = 10000;
 
 type ProbeResult = {
   ok: boolean;
@@ -26,42 +33,92 @@ type ProbeResult = {
 
 type BackendProbe = {
   detected: boolean;
-  confidence: Confidence;
+  confidence: GpuConfidence;
   reason: string;
 };
 
-async function runProbe(command: string, args: string[] = []): Promise<ProbeResult> {
+const CPU_FALLBACK: GpuDetectionResult = {
+  backend: 'cpu',
+  vendor: 'cpu',
+  // "No evidence found" is the opposite of high confidence - nothing was detected.
+  confidence: 'none',
+  decision: 'No supported GPU backend detected',
+};
+
+function runProbe(command: string, args: string[] = []): Promise<ProbeResult> {
   const commandLine = [command, ...args].join(' ');
-  try {
-    const { stdout } = await execFileAsync(command, args, { encoding: 'utf8', timeout: 3000 });
-    return { ok: true, command: commandLine, stdout: stdout.trim(), stderr: '', reason: 'command succeeded' };
-  } catch (error) {
-    const err = error as { stdout?: unknown; stderr?: unknown; message?: string };
-    return {
-      ok: false,
-      command: commandLine,
-      stdout: typeof err.stdout === 'string' ? err.stdout.trim() : '',
-      stderr: typeof err.stderr === 'string' ? err.stderr.trim() : '',
-      reason: err.message ?? 'command failed',
+
+  return new Promise<ProbeResult>((resolve) => {
+    let settled = false;
+    let deadline: NodeJS.Timeout | undefined;
+    let child: ChildProcess | undefined;
+
+    const finish = (result: ProbeResult) => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      clearTimeout(deadline);
+      resolve(result);
     };
+
+    child = execFile(
+      command,
+      args,
+      {
+        encoding: 'utf8',
+        timeout: PROBE_TIMEOUT_MS,
+        killSignal: 'SIGKILL',
+        // A packaged Electron app is a GUI-subsystem process with no console of its own, so without this every probe
+        // that shells out (`powershell` on every Windows machine, `nvidia-smi` on every NVIDIA one) flashes a console
+        // window in the user's face.
+        windowsHide: true,
+        maxBuffer: 1024 * 1024,
+      },
+      (error, stdout, stderr) => {
+        if (error) {
+          const err = error as { message?: string };
+          finish({
+            ok: false,
+            command: commandLine,
+            stdout: stdout.trim(),
+            stderr: stderr.trim(),
+            reason: err.message ?? 'command failed',
+          });
+          return;
+        }
+        finish({ ok: true, command: commandLine, stdout: stdout.trim(), stderr: '', reason: 'command succeeded' });
+      }
+    );
+
+    // Belt and braces against a child that will not die: settle regardless of whether the callback ever fires.
+    deadline = setTimeout(() => {
+      child?.kill('SIGKILL');
+      finish({ ok: false, command: commandLine, stdout: '', stderr: '', reason: 'command timed out' });
+    }, PROBE_TIMEOUT_MS + 500);
+  });
+}
+
+async function fileExists(filePath: string): Promise<boolean> {
+  try {
+    await fs.access(filePath);
+    return true;
+  } catch {
+    return false;
   }
 }
 
-function fileExists(filePath: string): boolean {
-  return fs.existsSync(filePath);
-}
-
-function readFile(filePath: string): string {
+async function readFile(filePath: string): Promise<string> {
   try {
-    return fs.readFileSync(filePath, 'utf8').trim();
+    return (await fs.readFile(filePath, 'utf8')).trim();
   } catch {
     return '';
   }
 }
 
-function listDir(dirPath: string): string[] {
+async function listDir(dirPath: string): Promise<string[]> {
   try {
-    return fs.readdirSync(dirPath);
+    return await fs.readdir(dirPath);
   } catch {
     return [];
   }
@@ -86,9 +143,47 @@ function numberValue(value: string | undefined): number {
   return Number.isFinite(parsed) ? parsed : 0;
 }
 
+/**
+ * gfx targets that ROCm's PyTorch wheels are actually built for.
+ *
+ * Without this check, every AMD APU on Linux (a 5700G, a 7840U, any Ryzen laptop with stock `amdgpu`) is a positive
+ * ROCm detection: its KFD topology node reports a gfx name, non-zero compute units and a valid device id, exactly like
+ * a discrete card. The user is then asked to confirm "we detected an AMD GPU (ROCm)" - which is *true* - and ends up
+ * with a multi-GB ROCm torch that dies with `hipErrorNoBinaryForGpu` at first generation. The confirmation prompt
+ * cannot save them, because there is nothing wrong with the statement they agreed to.
+ *
+ * Erring towards a short list is the safe direction: an unlisted target falls through to the CPU backend, which the
+ * user can still override by hand from the manual picker.
+ */
+const ROCM_SUPPORTED_GFX_TARGETS = new Set([
+  'gfx900',
+  'gfx906',
+  'gfx908',
+  'gfx90a',
+  'gfx942',
+  'gfx950',
+  'gfx1030',
+  'gfx1100',
+  'gfx1101',
+  'gfx1102',
+  'gfx1151',
+  'gfx1200',
+  'gfx1201',
+]);
+
+/** Normalize a gfx target - `rocminfo` reports feature suffixes, e.g. `gfx90a:sramecc+:xnack-`. */
+function normalizeGfxTarget(name: string): string {
+  return name.trim().toLowerCase().split(':')[0] ?? '';
+}
+
+function isRocmSupportedGfxTarget(name: string): boolean {
+  return ROCM_SUPPORTED_GFX_TARGETS.has(normalizeGfxTarget(name));
+}
+
 type KfdNode = { node: string; name: string; gpu_id: string; properties: string };
 
-function isUsableKfdGpuNode(node: KfdNode): boolean {
+/** Whether a KFD topology node describes a GPU at all (as opposed to the CPU node every machine has). */
+function isKfdGpuNode(node: KfdNode): boolean {
   const props = parseKfdProperties(node.properties);
   const name = node.name.trim();
 
@@ -109,34 +204,34 @@ function isUsableKfdGpuNode(node: KfdNode): boolean {
   return hasNonzeroGpuIdentity && hasComputeUnits && hasGfxTarget;
 }
 
-function probeKfdTopology(): { exists: boolean; hasUsableGpuNode: boolean } {
+async function probeKfdTopology(): Promise<{ exists: boolean; gfxTargets: string[] }> {
   const base = '/sys/class/kfd/kfd/topology/nodes';
-  const nodes: KfdNode[] = listDir(base).map((nodeName) => {
-    const nodePath = path.join(base, nodeName);
-    return {
-      node: nodeName,
-      name: readFile(path.join(nodePath, 'name')),
-      gpu_id: readFile(path.join(nodePath, 'gpu_id')),
-      properties: readFile(path.join(nodePath, 'properties')),
-    };
-  });
+  const nodeNames = await listDir(base);
+  const nodes: KfdNode[] = await Promise.all(
+    nodeNames.map(async (nodeName) => {
+      const nodePath = path.join(base, nodeName);
+      const [name, gpu_id, properties] = await Promise.all([
+        readFile(path.join(nodePath, 'name')),
+        readFile(path.join(nodePath, 'gpu_id')),
+        readFile(path.join(nodePath, 'properties')),
+      ]);
+      return { node: nodeName, name, gpu_id, properties };
+    })
+  );
 
   return {
-    exists: fs.existsSync(base),
-    hasUsableGpuNode: nodes.some(isUsableKfdGpuNode),
+    exists: await fileExists(base),
+    gfxTargets: nodes.filter(isKfdGpuNode).map((node) => node.name.trim()),
   };
 }
 
-function probeAmdRenderDevices(): { hasAmdRenderDevice: boolean } {
+async function probeAmdRenderDevices(): Promise<{ hasAmdRenderDevice: boolean }> {
   const drmPath = '/sys/class/drm';
-  const entries = listDir(drmPath).filter((name) => name.startsWith('renderD'));
+  const entries = (await listDir(drmPath)).filter((name) => name.startsWith('renderD'));
 
-  const hasAmdRenderDevice = entries.some((entry) => {
-    const vendor = readFile(path.join(drmPath, entry, 'device', 'vendor'));
-    return vendor.toLowerCase() === '0x1002';
-  });
+  const vendors = await Promise.all(entries.map((entry) => readFile(path.join(drmPath, entry, 'device', 'vendor'))));
 
-  return { hasAmdRenderDevice };
+  return { hasAmdRenderDevice: vendors.some((vendor) => vendor.toLowerCase() === '0x1002') };
 }
 
 async function hasNvidiaGpu(): Promise<BackendProbe> {
@@ -146,7 +241,10 @@ async function hasNvidiaGpu(): Promise<BackendProbe> {
     return { detected: true, confidence: 'high', reason: '`nvidia-smi -L` reported at least one GPU' };
   }
 
-  if (fileExists('/proc/driver/nvidia') || fileExists('/dev/nvidia0')) {
+  // `/proc/driver/nvidia` exists whenever `nvidia.ko` is loaded, even with zero usable devices (all of them bound to
+  // `vfio-pci` for passthrough, for instance), so require an actual GPU entry underneath it.
+  const nvidiaProcGpus = await listDir('/proc/driver/nvidia/gpus');
+  if (nvidiaProcGpus.length > 0 || (await fileExists('/dev/nvidia0'))) {
     return { detected: true, confidence: 'medium', reason: 'NVIDIA Linux device files exist' };
   }
 
@@ -154,43 +252,69 @@ async function hasNvidiaGpu(): Promise<BackendProbe> {
 }
 
 async function hasRocmGpu(): Promise<BackendProbe> {
+  // Every probe below is Linux-only (ROCm tools, `/sys/class/kfd`, `/sys/class/drm`). Without this guard an `amd-smi`
+  // that happens to be on a Windows PATH would route the user to `pins.torchIndexUrl.win32.rocm`, which does not
+  // exist - the exact outcome the Windows AMD probe below exists to prevent.
+  if (process.platform !== 'linux') {
+    return { detected: false, confidence: 'none', reason: 'ROCm is only supported on Linux' };
+  }
+
   // Each external probe has a 3s timeout; running them sequentially would cost up to ~9s of spinner time on a machine
   // without ROCm tools installed. They're independent, so run them concurrently and then evaluate in priority order.
-  const [amdSmi, rocmSmi, rocminfo] = await Promise.all([
+  const [amdSmi, rocmSmi, rocminfo, kfdTopology] = await Promise.all([
     runProbe('amd-smi', ['list']),
     runProbe('rocm-smi', ['--showproductname']),
     runProbe('rocminfo', []),
+    probeKfdTopology(),
   ]);
 
+  // Prefer the probes that name a gfx target, because that is the only signal that says whether a ROCm torch build
+  // exists for this hardware. `amd-smi`/`rocm-smi` only tell us that ROCm tooling is installed.
+  const rocminfoGfxTargets = rocminfo.ok
+    ? [...rocminfo.stdout.matchAll(/Name:\s+(gfx[0-9a-f]+(?::[\w+-]+)*)/gi)].map((match) => match[1] ?? '')
+    : [];
+  const gfxTargets = [...rocminfoGfxTargets, ...kfdTopology.gfxTargets].filter(Boolean);
+  const supportedGfxTargets = gfxTargets.filter(isRocmSupportedGfxTarget);
+
+  if (supportedGfxTargets.length > 0) {
+    return {
+      detected: true,
+      confidence: 'high',
+      reason: `Found an AMD GPU with a ROCm-supported target (${supportedGfxTargets.join(', ')})`,
+    };
+  }
+
+  if (gfxTargets.length > 0) {
+    return {
+      detected: false,
+      confidence: 'weak-signal',
+      reason: `We detected AMD graphics (${gfxTargets.join(', ')}), but PyTorch has no ROCm build for it, so Invoke will use your CPU`,
+    };
+  }
+
+  // No gfx target anywhere (e.g. a container where the KFD nodes are listable but their `properties` are not) - fall
+  // back to "ROCm tooling reports a device".
   if (
     amdSmi.ok &&
     /GPU:\s*\d+|ASIC|DEVICE/i.test(amdSmi.stdout) &&
     !/no devices|not found|failed/i.test(amdSmi.stdout)
   ) {
-    return { detected: true, confidence: 'high', reason: '`amd-smi list` reported at least one AMD GPU' };
+    return { detected: true, confidence: 'medium', reason: '`amd-smi list` reported at least one AMD GPU' };
   }
 
-  if (rocmSmi.ok && rocmSmi.stdout.length > 0 && !/no devices|not found|failed/i.test(rocmSmi.stdout)) {
-    return { detected: true, confidence: 'high', reason: '`rocm-smi --showproductname` returned GPU product output' };
+  // `rocm-smi` prints its banner and footer even with no supported device attached, so require an actual device row
+  // rather than just non-empty output.
+  if (rocmSmi.ok && /^GPU\[\d+\]/m.test(rocmSmi.stdout) && !/no devices|not found|failed/i.test(rocmSmi.stdout)) {
+    return { detected: true, confidence: 'medium', reason: '`rocm-smi --showproductname` reported a GPU' };
   }
 
-  const rocminfoHasGpuAgent =
-    rocminfo.ok && /Device Type:\s+GPU/i.test(rocminfo.stdout) && /Name:\s+gfx[0-9a-f]+/i.test(rocminfo.stdout);
-  if (rocminfoHasGpuAgent) {
-    return { detected: true, confidence: 'high', reason: '`rocminfo` reported a GPU agent with a gfx target' };
-  }
-
-  const kfdTopology = probeKfdTopology();
-  if (kfdTopology.hasUsableGpuNode) {
-    return { detected: true, confidence: 'medium', reason: 'KFD topology contains at least one usable GPU node' };
-  }
-
-  const renderDevices = probeAmdRenderDevices();
-  if (fileExists('/dev/kfd') || renderDevices.hasAmdRenderDevice || kfdTopology.exists) {
+  const renderDevices = await probeAmdRenderDevices();
+  if ((await fileExists('/dev/kfd')) || renderDevices.hasAmdRenderDevice || kfdTopology.exists) {
     return {
       detected: false,
       confidence: 'weak-signal',
-      reason: 'AMD/KFD evidence exists, but no ROCm tool or KFD topology node confirmed a usable ROCm GPU',
+      reason:
+        'We detected AMD graphics hardware, but could not confirm a ROCm-capable GPU, so Invoke will use your CPU',
     };
   }
 
@@ -243,10 +367,7 @@ async function hasWindowsAmdGpu(): Promise<BackendProbe> {
   return { detected: false, confidence: 'none', reason: 'No AMD display adapter reported by Windows' };
 }
 
-/**
- * Detect the most likely compute backend for this machine. The result is advisory and always user-overridable.
- */
-export const detectGpu = async (): Promise<GpuDetectionResult> => {
+async function detect(): Promise<GpuDetectionResult> {
   const [nvidia, rocm, mac, windowsAmd] = await Promise.all([
     hasNvidiaGpu(),
     hasRocmGpu(),
@@ -254,40 +375,57 @@ export const detectGpu = async (): Promise<GpuDetectionResult> => {
     hasWindowsAmdGpu(),
   ]);
 
-  let backend: GpuBackend;
-  let vendor: GpuVendor;
-  let confidence: Confidence;
-  let decision: string;
-
   if (nvidia.detected) {
-    backend = 'cuda';
-    vendor = 'nvidia';
-    confidence = nvidia.confidence;
-    decision = nvidia.reason;
-  } else if (rocm.detected) {
-    backend = 'rocm';
-    vendor = 'amd';
-    confidence = rocm.confidence;
-    decision = rocm.reason;
-  } else if (mac.detected) {
-    backend = 'metal';
-    vendor = 'apple';
-    confidence = mac.confidence;
-    decision = mac.reason;
-  } else if (windowsAmd.detected) {
-    // A real AMD GPU, but no ROCm on Windows - the usable backend is still CPU. We surface the vendor so the UI can
-    // explain why, rather than claiming there's no GPU at all.
-    backend = 'cpu';
-    vendor = 'amd';
-    confidence = windowsAmd.confidence;
-    decision = 'AMD GPU detected on Windows, where ROCm is not supported - Invoke will use the CPU';
-  } else {
-    backend = 'cpu';
-    vendor = 'cpu';
-    // "No evidence found" is the opposite of high confidence - nothing was detected.
-    confidence = 'none';
-    decision = 'No supported GPU backend detected';
+    return { backend: 'cuda', vendor: 'nvidia', confidence: nvidia.confidence, decision: nvidia.reason };
   }
 
-  return { backend, vendor, confidence, decision };
+  if (rocm.detected) {
+    return { backend: 'rocm', vendor: 'amd', confidence: rocm.confidence, decision: rocm.reason };
+  }
+
+  if (mac.detected) {
+    return { backend: 'metal', vendor: 'apple', confidence: mac.confidence, decision: mac.reason };
+  }
+
+  if (windowsAmd.detected) {
+    // A real AMD GPU, but no ROCm on Windows - the usable backend is still CPU. We surface the vendor so the UI can
+    // explain why, rather than claiming there's no GPU at all.
+    return {
+      backend: 'cpu',
+      vendor: 'amd',
+      confidence: windowsAmd.confidence,
+      decision: 'We detected an AMD GPU, but ROCm is not supported on Windows, so Invoke will use your CPU',
+    };
+  }
+
+  if (rocm.confidence === 'weak-signal') {
+    // We saw AMD hardware but could not confirm a ROCm-capable GPU. The backend is still CPU, but "no dedicated GPU"
+    // would be a lie to someone staring at a Radeon - carry the reason through so the UI can explain itself.
+    return { backend: 'cpu', vendor: 'amd', confidence: 'weak-signal', decision: rocm.reason };
+  }
+
+  return CPU_FALLBACK;
+}
+
+/**
+ * Detect the most likely compute backend for this machine. The result is advisory and always user-overridable.
+ *
+ * An individual probe failing degrades to "no evidence for that backend". Blowing the overall deadline instead
+ * *rejects*: we genuinely don't know what this machine has, and reporting "no dedicated GPU" would be indistinguishable
+ * from a confident answer. The caller falls back to the manual picker, which is the honest outcome.
+ */
+export const detectGpu = async (): Promise<GpuDetectionResult> => {
+  let deadline: NodeJS.Timeout | undefined;
+  const timeout = new Promise<never>((_resolve, reject) => {
+    deadline = setTimeout(
+      () => reject(new Error(`GPU detection timed out after ${DETECTION_TIMEOUT_MS}ms`)),
+      DETECTION_TIMEOUT_MS
+    );
+  });
+
+  try {
+    return await Promise.race([detect(), timeout]);
+  } finally {
+    clearTimeout(deadline);
+  }
 };

--- a/src/main/gpu-detection.ts
+++ b/src/main/gpu-detection.ts
@@ -124,6 +124,14 @@ async function listDir(dirPath: string): Promise<string[]> {
   }
 }
 
+async function readLink(linkPath: string): Promise<string> {
+  try {
+    return await fs.readlink(linkPath);
+  } catch {
+    return '';
+  }
+}
+
 function parseKfdProperties(text: string): Record<string, string> {
   const result: Record<string, string> = {};
   for (const line of text.split(/\r?\n/)) {
@@ -225,13 +233,39 @@ async function probeKfdTopology(): Promise<{ exists: boolean; gfxTargets: string
   };
 }
 
-async function probeAmdRenderDevices(): Promise<{ hasAmdRenderDevice: boolean }> {
+/** PCI vendor ids as sysfs reports them. */
+const PCI_VENDOR_AMD = '0x1002';
+const PCI_VENDOR_INTEL = '0x8086';
+
+type DrmDevice = {
+  /** PCI vendor id, e.g. `0x8086`. */
+  vendor: string;
+  /** PCI device id, e.g. `0x56a0`. */
+  device: string;
+  /** Kernel driver bound to the device, e.g. `i915`, `xe`, `amdgpu`. Empty when it cannot be read. */
+  driver: string;
+};
+
+/**
+ * Enumerate the render nodes under `/sys/class/drm`, with the PCI ids and kernel driver of each. One pass serves both
+ * the AMD and the Intel probes.
+ */
+async function probeDrmDevices(): Promise<DrmDevice[]> {
   const drmPath = '/sys/class/drm';
   const entries = (await listDir(drmPath)).filter((name) => name.startsWith('renderD'));
 
-  const vendors = await Promise.all(entries.map((entry) => readFile(path.join(drmPath, entry, 'device', 'vendor'))));
-
-  return { hasAmdRenderDevice: vendors.some((vendor) => vendor.toLowerCase() === '0x1002') };
+  return Promise.all(
+    entries.map(async (entry) => {
+      const devicePath = path.join(drmPath, entry, 'device');
+      const [vendor, device, driver] = await Promise.all([
+        readFile(path.join(devicePath, 'vendor')),
+        readFile(path.join(devicePath, 'device')),
+        // `device/driver` is a symlink into /sys/bus/pci/drivers/<name>; the basename is the driver.
+        readLink(path.join(devicePath, 'driver')),
+      ]);
+      return { vendor: vendor.toLowerCase(), device: device.toLowerCase(), driver: path.basename(driver) };
+    })
+  );
 }
 
 async function hasNvidiaGpu(): Promise<BackendProbe> {
@@ -251,7 +285,7 @@ async function hasNvidiaGpu(): Promise<BackendProbe> {
   return { detected: false, confidence: 'none', reason: 'No NVIDIA evidence found' };
 }
 
-async function hasRocmGpu(): Promise<BackendProbe> {
+async function hasRocmGpu(drmDevices: Promise<DrmDevice[]>): Promise<BackendProbe> {
   // Every probe below is Linux-only (ROCm tools, `/sys/class/kfd`, `/sys/class/drm`). Without this guard an `amd-smi`
   // that happens to be on a Windows PATH would route the user to `pins.torchIndexUrl.win32.rocm`, which does not
   // exist - the exact outcome the Windows AMD probe below exists to prevent.
@@ -308,8 +342,8 @@ async function hasRocmGpu(): Promise<BackendProbe> {
     return { detected: true, confidence: 'medium', reason: '`rocm-smi --showproductname` reported a GPU' };
   }
 
-  const renderDevices = await probeAmdRenderDevices();
-  if ((await fileExists('/dev/kfd')) || renderDevices.hasAmdRenderDevice || kfdTopology.exists) {
+  const hasAmdRenderDevice = (await drmDevices).some((device) => device.vendor === PCI_VENDOR_AMD);
+  if ((await fileExists('/dev/kfd')) || hasAmdRenderDevice || kfdTopology.exists) {
     return {
       detected: false,
       confidence: 'weak-signal',
@@ -344,13 +378,13 @@ async function hasMacGpuCapabilities(): Promise<BackendProbe> {
 }
 
 /**
- * Detect a discrete AMD GPU on Windows. There is no supported ROCm-on-Windows install path, so this never yields a
- * usable GPU backend - it exists purely so we can tell the user "we saw your AMD card, but Windows will use the CPU"
- * instead of the misleading "no dedicated GPU detected". These are exactly the users the custom-index field targets.
+ * The display adapter names Windows reports, one per line. Empty on other platforms or if the query fails.
+ *
+ * Shared by the AMD and Intel probes so a packaged app spawns `powershell` once, not once per vendor.
  */
-async function hasWindowsAmdGpu(): Promise<BackendProbe> {
+async function probeWindowsDisplayAdapters(): Promise<string[]> {
   if (process.platform !== 'win32') {
-    return { detected: false, confidence: 'none', reason: 'Not Windows' };
+    return [];
   }
 
   const videoControllers = await runProbe('powershell', [
@@ -360,19 +394,129 @@ async function hasWindowsAmdGpu(): Promise<BackendProbe> {
     'Get-CimInstance Win32_VideoController | ForEach-Object { $_.Name }',
   ]);
 
-  if (videoControllers.ok && /\b(AMD|Radeon|ATI)\b/i.test(videoControllers.stdout)) {
+  if (!videoControllers.ok) {
+    return [];
+  }
+
+  return videoControllers.stdout
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter(Boolean);
+}
+
+/**
+ * Detect a discrete AMD GPU on Windows. There is no supported ROCm-on-Windows install path, so this never yields a
+ * usable GPU backend - it exists purely so we can tell the user "we saw your AMD card, but Windows will use the CPU"
+ * instead of the misleading "no dedicated GPU detected". These are exactly the users the custom-index field targets.
+ */
+async function hasWindowsAmdGpu(windowsAdapters: Promise<string[]>): Promise<BackendProbe> {
+  if (process.platform !== 'win32') {
+    return { detected: false, confidence: 'none', reason: 'Not Windows' };
+  }
+
+  if ((await windowsAdapters).some((adapter) => /\b(AMD|Radeon|ATI)\b/i.test(adapter))) {
     return { detected: true, confidence: 'medium', reason: 'Windows reported an AMD/Radeon display adapter' };
   }
 
   return { detected: false, confidence: 'none', reason: 'No AMD display adapter reported by Windows' };
 }
 
+/**
+ * PCI device id prefixes of the Intel GPUs PyTorch's XPU build supports.
+ *
+ * Intel's supported list is the Arc graphics family (A-series and B-series), Core Ultra processors with built-in Arc
+ * graphics, and Data Center GPU Max. Everything older - UHD Graphics, pre-Arc Iris Xe - has no XPU support, and
+ * installing the +xpu wheels there produces a multi-GB install that cannot run. As with the ROCm gfx allowlist, an
+ * unrecognised device falls through to the CPU backend and the user can still pick Intel by hand.
+ *
+ * - `0x56xx` covers DG2 / Arc A-series, desktop (`56a0` A770, `56a1` A750, ...) and mobile (`5690` A770M, ...).
+ * - `0xe2xx` covers BMG / Arc B-series.
+ * - `0x0bdx` covers Data Center GPU Max (Ponte Vecchio).
+ */
+const XPU_SUPPORTED_PCI_DEVICE_PREFIXES = ['0x56', '0xe2', '0x0bd'];
+
+/**
+ * Kernel drivers that only ever bind Xe-architecture hardware. Anything on the `xe` driver (Lunar Lake and newer
+ * integrated Arc graphics, Battlemage) is XPU-capable, which saves maintaining device ids for the Core Ultra iGPUs.
+ * `i915` is not usable as a signal - it covers everything back to Sandy Bridge - hence the device id list above.
+ */
+const XPU_CAPABLE_DRIVERS = ['xe'];
+
+/**
+ * Detect an Intel GPU that PyTorch's XPU backend can actually use.
+ *
+ * PyTorch publishes `+xpu` wheels for linux-x86_64 and windows-amd64 only, so this is guarded to those platforms - on
+ * macOS an Intel iGPU means Metal or CPU, never XPU.
+ */
+async function hasIntelXpuGpu(
+  drmDevices: Promise<DrmDevice[]>,
+  windowsAdapters: Promise<string[]>
+): Promise<BackendProbe> {
+  if (process.platform === 'win32') {
+    // Intel brands exactly the XPU-capable GPUs as "Arc" - the A/B-series cards and the Core Ultra integrated GPU all
+    // report as "Intel(R) Arc(TM) ...". An "Intel(R) UHD Graphics 620" is a real Intel GPU with no XPU support.
+    const adapters = await windowsAdapters;
+    const intelAdapters = adapters.filter((adapter) => /\bintel\b/i.test(adapter));
+    const arcAdapters = intelAdapters.filter((adapter) => /\barc\b/i.test(adapter));
+
+    if (arcAdapters.length > 0) {
+      return { detected: true, confidence: 'high', reason: `Windows reported an Intel Arc GPU (${arcAdapters[0]})` };
+    }
+
+    if (intelAdapters.length > 0) {
+      return {
+        detected: false,
+        confidence: 'weak-signal',
+        reason: `We detected Intel graphics (${intelAdapters[0]}), but PyTorch's XPU build supports Arc graphics only, so Invoke will use your CPU`,
+      };
+    }
+
+    return { detected: false, confidence: 'none', reason: 'No Intel display adapter reported by Windows' };
+  }
+
+  if (process.platform !== 'linux') {
+    return { detected: false, confidence: 'none', reason: 'PyTorch publishes no XPU wheels for this platform' };
+  }
+
+  const intelDevices = (await drmDevices).filter((device) => device.vendor === PCI_VENDOR_INTEL);
+
+  if (intelDevices.length === 0) {
+    return { detected: false, confidence: 'none', reason: 'No Intel evidence found' };
+  }
+
+  const supported = intelDevices.filter(
+    (device) =>
+      XPU_CAPABLE_DRIVERS.includes(device.driver) ||
+      XPU_SUPPORTED_PCI_DEVICE_PREFIXES.some((prefix) => device.device.startsWith(prefix))
+  );
+
+  if (supported.length > 0) {
+    return {
+      detected: true,
+      confidence: 'high',
+      reason: `Found an Intel GPU with XPU support (PCI ${supported[0]?.device}, ${supported[0]?.driver} driver)`,
+    };
+  }
+
+  return {
+    detected: false,
+    confidence: 'weak-signal',
+    reason: `We detected Intel graphics (PCI ${intelDevices[0]?.device}), but PyTorch's XPU build supports Arc graphics only, so Invoke will use your CPU`,
+  };
+}
+
 async function detect(): Promise<GpuDetectionResult> {
-  const [nvidia, rocm, mac, windowsAmd] = await Promise.all([
+  // Started, not awaited: several probes consume these and would otherwise either run the query twice or serialise
+  // behind each other. Every probe still runs concurrently below.
+  const drmDevices = probeDrmDevices();
+  const windowsAdapters = probeWindowsDisplayAdapters();
+
+  const [nvidia, rocm, intel, mac, windowsAmd] = await Promise.all([
     hasNvidiaGpu(),
-    hasRocmGpu(),
+    hasRocmGpu(drmDevices),
+    hasIntelXpuGpu(drmDevices, windowsAdapters),
     hasMacGpuCapabilities(),
-    hasWindowsAmdGpu(),
+    hasWindowsAmdGpu(windowsAdapters),
   ]);
 
   if (nvidia.detected) {
@@ -381,6 +525,11 @@ async function detect(): Promise<GpuDetectionResult> {
 
   if (rocm.detected) {
     return { backend: 'rocm', vendor: 'amd', confidence: rocm.confidence, decision: rocm.reason };
+  }
+
+  // After the discrete-GPU backends: a machine with an NVIDIA card and an Intel iGPU should install CUDA.
+  if (intel.detected) {
+    return { backend: 'xpu', vendor: 'intel', confidence: intel.confidence, decision: intel.reason };
   }
 
   if (mac.detected) {
@@ -398,10 +547,16 @@ async function detect(): Promise<GpuDetectionResult> {
     };
   }
 
+  // We saw hardware from a vendor but could not confirm a usable backend for it. The backend is still CPU, but "no
+  // dedicated GPU" would be a lie to someone staring at a Radeon or an Arc - carry the reason through so the UI can
+  // explain itself. AMD first: a discrete Radeon is more likely to be the card the user cares about than the Intel
+  // iGPU that also sits in the same machine.
   if (rocm.confidence === 'weak-signal') {
-    // We saw AMD hardware but could not confirm a ROCm-capable GPU. The backend is still CPU, but "no dedicated GPU"
-    // would be a lie to someone staring at a Radeon - carry the reason through so the UI can explain itself.
     return { backend: 'cpu', vendor: 'amd', confidence: 'weak-signal', decision: rocm.reason };
+  }
+
+  if (intel.confidence === 'weak-signal') {
+    return { backend: 'cpu', vendor: 'intel', confidence: 'weak-signal', decision: intel.reason };
   }
 
   return CPU_FALLBACK;

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -3,6 +3,7 @@ import { join } from 'path';
 import { assert } from 'tsafe';
 
 import { createConsoleManager } from '@/main/console-manager';
+import { detectGpu } from '@/main/gpu-detection';
 import { createInstallManager } from '@/main/install-manager';
 import { createInvokeManager } from '@/main/invoke-manager';
 import { MainProcessManager } from '@/main/main-process-manager';
@@ -127,4 +128,5 @@ main.ipc.handle('util:get-path-exists', (_, path) => pathExists(path));
 main.ipc.handle('util:get-os', () => getOperatingSystem());
 main.ipc.handle('util:open-directory', (_, path) => shell.openPath(path));
 main.ipc.handle('util:get-launcher-version', () => app.getVersion());
+main.ipc.handle('util:detect-gpu', () => detectGpu());
 //#endregion

--- a/src/main/install-manager.ts
+++ b/src/main/install-manager.ts
@@ -15,7 +15,7 @@ import { SimpleLogger } from '@/lib/simple-logger';
 import { FIRST_RUN_MARKER_FILENAME } from '@/main/constants';
 import { getInstallationDetails, getTorchPlatform, getUVExecutablePath, isDirectory, isFile } from '@/main/util';
 import type { InvokeReleaseInstallFiles } from '@/shared/pins';
-import { getInvokeReleaseInstallFiles, getPins } from '@/shared/pins';
+import { getInvokeReleaseInstallFiles, getPins, getTorchPackagesFromLock } from '@/shared/pins';
 import type {
   GpuType,
   InstallProcessStatus,
@@ -184,7 +184,15 @@ export class InstallManager {
     this.onStatusChange(this.status);
   };
 
-  startInstall = async (location: string, gpuType: GpuType, version: string, repair?: boolean) => {
+  startInstall = async (
+    location: string,
+    gpuType: GpuType,
+    version: string,
+    customTorchIndexUrl?: string,
+    repair?: boolean
+  ) => {
+    // Normalize the optional custom torch index override: an empty/whitespace value means "use defaults".
+    const torchIndexOverride = customTorchIndexUrl?.trim() || undefined;
     /**
      * Installation is a 2-step process:
      * - Create a virtual environment.
@@ -319,6 +327,9 @@ export class InstallManager {
         useBootstrapInstall ? 'frozen Invoke pyproject.toml and uv.lock' : 'legacy package metadata install'
       }\r\n`
     );
+    if (torchIndexOverride) {
+      this.log.info(c.magenta(`- Torch index override: ${torchIndexOverride}\r\n`));
+    }
 
     if (repair) {
       this.log.info(c.magenta('Repair mode enabled:\r\n'));
@@ -510,6 +521,13 @@ export class InstallManager {
       }
 
       const bootstrapProjectPath = bootstrapProjectResult.value;
+
+      // When a custom torch index is set, we install the torch-family packages from that index instead of the source
+      // the lockfile records. To avoid downloading torch twice (once from the lock during `uv sync`, once from the
+      // custom index afterwards), we skip those packages during the sync and install them once from the custom index
+      // below. `uv sync --frozen` cannot pull them from a different index in-place, so a separate install is required.
+      const torchPackages = torchIndexOverride ? getTorchPackagesFromLock(releaseFiles.uvLock, torchPlatform) : [];
+
       const syncInvokeArgs = [
         // Use `uv sync` against the selected Invoke release's pyproject.toml and lockfile.
         'sync',
@@ -534,6 +552,11 @@ export class InstallManager {
 
       for (const extra of invokeExtras) {
         syncInvokeArgs.push('--extra', extra);
+      }
+
+      // Skip the torch-family packages during sync - they are reinstalled from the custom index below.
+      for (const pkg of torchPackages) {
+        syncInvokeArgs.push('--no-install-package', pkg.name);
       }
 
       this.log.info(c.cyan('Syncing invokeai environment...\r\n'));
@@ -569,6 +592,65 @@ export class InstallManager {
         return;
       }
 
+      // If a custom torch index is set, install the torch-family packages from it. These were skipped during `uv sync`
+      // (see `--no-install-package` above), so this is a single download from the user's index rather than a second
+      // one. This deliberately departs from the lock's recorded source - which is exactly what the user is asking for
+      // when they set the field (e.g. cu126 on 20xx cards, ROCm on Windows).
+      if (torchIndexOverride) {
+        if (torchPackages.length === 0) {
+          this.log.warn(
+            c.yellow(
+              `Custom torch index is set, but no ${torchPlatform} torch packages were found in the Invoke release lockfile - skipping the torch install from the custom index.\r\n`
+            )
+          );
+        } else {
+          const reinstallTorchArgs = [
+            'pip',
+            'install',
+            '--python',
+            venvPath,
+            '--python-preference',
+            'only-managed',
+            // Pull the torch packages from the user-provided index instead of the one recorded in the lockfile.
+            `--index=${torchIndexOverride}`,
+            // The torch packages were skipped during sync; on a reinstall/update an older build may still be present,
+            // so force the install to guarantee the packages come from the custom index.
+            '--force-reinstall',
+            // Everything else is already installed by `uv sync`; only install the torch packages themselves.
+            '--no-deps',
+            '--compile-bytecode',
+            ...torchPackages.map(({ name, version }) => `${name}==${version}`),
+          ];
+
+          this.log.info(c.cyan('Installing torch from custom index...\r\n'));
+          this.log.info(`> VIRTUAL_ENV=${venvPath} ${uvPath} ${reinstallTorchArgs.join(' ')}\r\n`);
+
+          const reinstallTorchResult = await withResultAsync(() =>
+            this.runCommand(uvPath, reinstallTorchArgs, { ...runProcessOptions, cwd: location })
+          );
+
+          if (reinstallTorchResult.isErr()) {
+            this.log.error(
+              c.red(`Failed to reinstall torch from custom index: ${reinstallTorchResult.error.message}\r\n`)
+            );
+            this.updateStatus({
+              type: 'error',
+              error: {
+                message: 'Failed to reinstall torch from custom index',
+                context: serializeError(reinstallTorchResult.error),
+              },
+            });
+            return;
+          }
+
+          if (reinstallTorchResult.value === 'canceled') {
+            this.log.warn(c.yellow('Installation canceled\r\n'));
+            this.updateStatus({ type: 'canceled' });
+            return;
+          }
+        }
+      }
+
       installInvokeArgs = [
         // Install the published Invoke package after syncing its locked dependencies. Dependencies are installed by
         // `uv sync` above, so do not resolve them again from wheel metadata.
@@ -602,7 +684,7 @@ export class InstallManager {
         '--compile-bytecode',
       ];
 
-      const torchIndexUrl = pins.torchIndexUrl[systemPlatform][torchPlatform];
+      const torchIndexUrl = torchIndexOverride ?? pins.torchIndexUrl[systemPlatform][torchPlatform];
       if (torchIndexUrl) {
         installInvokeArgs.push(`--index=${torchIndexUrl}`);
       }
@@ -694,8 +776,8 @@ export const createInstallManager = (arg: {
     },
   });
 
-  ipc.handle('install-process:start-install', (_, installationPath, gpuType, version, repair) => {
-    installManager.startInstall(installationPath, gpuType, version, repair);
+  ipc.handle('install-process:start-install', (_, installationPath, gpuType, version, customTorchIndexUrl, repair) => {
+    installManager.startInstall(installationPath, gpuType, version, customTorchIndexUrl, repair);
   });
   ipc.handle('install-process:cancel-install', async () => {
     await installManager.cancelInstall();

--- a/src/main/install-manager.ts
+++ b/src/main/install-manager.ts
@@ -24,6 +24,7 @@ import type {
   LogEntry,
   WithTimestamp,
 } from '@/shared/types';
+import { isCustomTorchIndexUrlInvalid, redactUrlCredentials } from '@/shared/url';
 
 const BOOTSTRAP_PROJECT_DIR_NAME = '.launcher-bootstrap';
 const MIN_BOOTSTRAP_INSTALL_VERSION = '6.14.0rc1';
@@ -193,6 +194,22 @@ export class InstallManager {
   ) => {
     // Normalize the optional custom torch index override: an empty/whitespace value means "use defaults".
     const torchIndexOverride = customTorchIndexUrl?.trim() || undefined;
+
+    // Defense-in-depth: the renderer already rejects non-http(s) URLs at entry, but the main process should not trust
+    // that. A bad value here would otherwise surface as a cryptic uv error minutes into the install.
+    if (torchIndexOverride && isCustomTorchIndexUrlInvalid(torchIndexOverride)) {
+      const message = `Invalid custom torch index URL: ${redactUrlCredentials(torchIndexOverride)}`;
+      this.log.error(c.red(`${message}\r\n`));
+      this.updateStatus({ type: 'error', error: { message } });
+      return;
+    }
+
+    // Any credentials embedded in the override must never be echoed into the install log or the surfaced command lines.
+    const redactedTorchIndexOverride = torchIndexOverride ? redactUrlCredentials(torchIndexOverride) : undefined;
+    const redactForLog = (text: string): string =>
+      torchIndexOverride && redactedTorchIndexOverride
+        ? text.split(torchIndexOverride).join(redactedTorchIndexOverride)
+        : text;
     /**
      * Installation is a 2-step process:
      * - Create a virtual environment.
@@ -328,7 +345,20 @@ export class InstallManager {
       }\r\n`
     );
     if (torchIndexOverride) {
-      this.log.info(c.magenta(`- Torch index override: ${torchIndexOverride}\r\n`));
+      this.log.info(c.magenta(`- Torch index override: ${redactedTorchIndexOverride}\r\n`));
+
+      // xformers (installed only on nvidia<30xx) is pulled from Invoke's default index and built against the lock's
+      // default CUDA torch. If the user swaps torch to a different CUDA build via the override, the two can have
+      // mismatched ABIs, which is a known source of import errors or crashes. Warn, but don't block - the user opted in.
+      if (invokeExtras.includes('xformers')) {
+        this.log.warn(
+          c.yellow(
+            '- Warning: a custom torch index is combined with the xformers extra (20xx-series cards). xformers is built ' +
+              "against Invoke's default CUDA torch, so a mismatched custom CUDA build may cause import errors or " +
+              'crashes.\r\n'
+          )
+        );
+      }
     }
 
     if (repair) {
@@ -611,8 +641,12 @@ export class InstallManager {
             venvPath,
             '--python-preference',
             'only-managed',
-            // Pull the torch packages from the user-provided index instead of the one recorded in the lockfile.
-            `--index=${torchIndexOverride}`,
+            // Pull the torch packages from the user-provided index *instead of* PyPI, not in addition to it. `--index`
+            // only *prepends* an index, so uv silently falls back to the default PyPI wheel when the custom index lacks
+            // the pinned (tag-stripped) version - installing the wrong backend with no error, the exact failure this
+            // feature prevents. `--index-url` makes the custom index the sole index, so a mismatch fails loudly. This is
+            // safe here because the step is `--no-deps` and requests only the torch-family packages.
+            `--index-url=${torchIndexOverride}`,
             // The torch packages were skipped during sync; on a reinstall/update an older build may still be present,
             // so force the install to guarantee the packages come from the custom index.
             '--force-reinstall',
@@ -623,7 +657,7 @@ export class InstallManager {
           ];
 
           this.log.info(c.cyan('Installing torch from custom index...\r\n'));
-          this.log.info(`> VIRTUAL_ENV=${venvPath} ${uvPath} ${reinstallTorchArgs.join(' ')}\r\n`);
+          this.log.info(redactForLog(`> VIRTUAL_ENV=${venvPath} ${uvPath} ${reinstallTorchArgs.join(' ')}\r\n`));
 
           const reinstallTorchResult = await withResultAsync(() =>
             this.runCommand(uvPath, reinstallTorchArgs, { ...runProcessOptions, cwd: location })
@@ -691,7 +725,7 @@ export class InstallManager {
     }
 
     this.log.info(c.cyan('Installing invokeai package...\r\n'));
-    this.log.info(`> VIRTUAL_ENV=${venvPath} ${uvPath} ${installInvokeArgs.join(' ')}\r\n`);
+    this.log.info(redactForLog(`> VIRTUAL_ENV=${venvPath} ${uvPath} ${installInvokeArgs.join(' ')}\r\n`));
 
     const installAppResult = await withResultAsync(() =>
       this.runCommand(uvPath, installInvokeArgs, { ...runProcessOptions, cwd: location })

--- a/src/main/install-manager.ts
+++ b/src/main/install-manager.ts
@@ -13,6 +13,7 @@ import { DEFAULT_ENV } from '@/lib/pty-utils';
 import { withResultAsync } from '@/lib/result';
 import { SimpleLogger } from '@/lib/simple-logger';
 import { FIRST_RUN_MARKER_FILENAME } from '@/main/constants';
+import { buildCustomTorchInstallCommand } from '@/main/torch-index';
 import { getInstallationDetails, getTorchPlatform, getUVExecutablePath, isDirectory, isFile } from '@/main/util';
 import type { InvokeReleaseInstallFiles } from '@/shared/pins';
 import { getInvokeReleaseInstallFiles, getPins, getTorchPackagesFromLock } from '@/shared/pins';
@@ -24,7 +25,7 @@ import type {
   LogEntry,
   WithTimestamp,
 } from '@/shared/types';
-import { isCustomTorchIndexUrlInvalid, redactUrlCredentials } from '@/shared/url';
+import { hasInsecureCredentials, isCustomTorchIndexUrlInvalid, redactUrlCredentials } from '@/shared/url';
 
 const BOOTSTRAP_PROJECT_DIR_NAME = '.launcher-bootstrap';
 const MIN_BOOTSTRAP_INSTALL_VERSION = '6.14.0rc1';
@@ -195,15 +196,6 @@ export class InstallManager {
     // Normalize the optional custom torch index override: an empty/whitespace value means "use defaults".
     const torchIndexOverride = customTorchIndexUrl?.trim() || undefined;
 
-    // Defense-in-depth: the renderer already rejects non-http(s) URLs at entry, but the main process should not trust
-    // that. A bad value here would otherwise surface as a cryptic uv error minutes into the install.
-    if (torchIndexOverride && isCustomTorchIndexUrlInvalid(torchIndexOverride)) {
-      const message = `Invalid custom torch index URL: ${redactUrlCredentials(torchIndexOverride)}`;
-      this.log.error(c.red(`${message}\r\n`));
-      this.updateStatus({ type: 'error', error: { message } });
-      return;
-    }
-
     // Any credentials embedded in the override must never be echoed into the install log or the surfaced command lines.
     const redactedTorchIndexOverride = torchIndexOverride ? redactUrlCredentials(torchIndexOverride) : undefined;
     const redactForLog = (text: string): string =>
@@ -224,6 +216,29 @@ export class InstallManager {
     this.isCancellationRequested = false;
     this.updateStatus({ type: 'starting' });
     // Do some initial checks and setup
+
+    // Defense-in-depth: the renderer already rejects non-http(s) URLs at entry, but the main process should not trust
+    // that. A bad value here would otherwise surface as a cryptic uv error minutes into the install.
+    //
+    // These checks must come *after* the `starting` status above: the Install step only renders its Finish button once
+    // it has seen an active -> inactive transition, so returning before it would leave the user on a screen with no way
+    // out but restarting the app.
+    if (torchIndexOverride && isCustomTorchIndexUrlInvalid(torchIndexOverride)) {
+      const message = `Invalid custom torch index URL: ${redactUrlCredentials(torchIndexOverride)}`;
+      this.log.error(c.red(`${message}\r\n`));
+      this.updateStatus({ type: 'error', error: { message } });
+      return;
+    }
+
+    // There is no macOS wheel on any PyTorch device index - macOS torch comes from PyPI and uses MPS. Pointing the
+    // override at e.g. a CUDA index there cannot resolve, and would only fail after the full dependency sync. The
+    // Configure step hides the field on macOS; this is the matching guard for a direct IPC call.
+    if (torchIndexOverride && process.platform === 'darwin') {
+      const message = 'A custom PyTorch index is not supported on macOS - torch for macOS is published on PyPI.';
+      this.log.error(c.red(`${message}\r\n`));
+      this.updateStatus({ type: 'error', error: { message } });
+      return;
+    }
 
     // First make sure the install location is valid (e.g. it's a folder that exists)
     const locationCheckResult = await withResultAsync(async () => {
@@ -346,6 +361,15 @@ export class InstallManager {
     );
     if (torchIndexOverride) {
       this.log.info(c.magenta(`- Torch index override: ${redactedTorchIndexOverride}\r\n`));
+
+      if (hasInsecureCredentials(torchIndexOverride)) {
+        this.log.warn(
+          c.yellow(
+            '- Warning: the custom torch index URL carries credentials over plain http, so they are sent unencrypted. ' +
+              'Use https if your index supports it.\r\n'
+          )
+        );
+      }
 
       // xformers (installed only on nvidia<30xx) is pulled from Invoke's default index and built against the lock's
       // default CUDA torch. If the user swaps torch to a different CUDA build via the override, the two can have
@@ -625,63 +649,67 @@ export class InstallManager {
       // If a custom torch index is set, install the torch-family packages from it. These were skipped during `uv sync`
       // (see `--no-install-package` above), so this is a single download from the user's index rather than a second
       // one. This deliberately departs from the lock's recorded source - which is exactly what the user is asking for
-      // when they set the field (e.g. cu126 on 20xx cards, ROCm on Windows).
+      // when they set the field (e.g. a cu126 build of the same torch version on 20xx cards).
       if (torchIndexOverride) {
         if (torchPackages.length === 0) {
-          this.log.warn(
-            c.yellow(
-              `Custom torch index is set, but no ${torchPlatform} torch packages were found in the Invoke release lockfile - skipping the torch install from the custom index.\r\n`
+          // The torch packages are selected by matching each package's `source` in a lockfile we fetch at runtime from
+          // the Invoke repo - so an upstream change (a host migration, a nightly/test channel) can make this empty
+          // without anything in this repo changing. Silently continuing would install the default torch while the
+          // Review step and the log both told the user it came from their index, and still report success. Fail loudly.
+          const message = `Custom torch index is set, but no ${torchPlatform} torch packages were found in the Invoke release lockfile, so the override cannot be applied.`;
+          this.log.error(c.red(`${message}\r\n`));
+          this.log.error(
+            c.red('Remove the custom PyTorch index to install with the versions Invoke ships, or report this.\r\n')
+          );
+          this.updateStatus({ type: 'error', error: { message } });
+          return;
+        }
+
+        const { args: reinstallTorchArgs, env: torchIndexEnv } = buildCustomTorchInstallCommand(
+          venvPath,
+          torchIndexOverride,
+          torchPackages
+        );
+
+        this.log.info(c.cyan('Installing torch from custom index...\r\n'));
+        this.log.info(redactForLog(`> VIRTUAL_ENV=${venvPath} ${uvPath} ${reinstallTorchArgs.join(' ')}\r\n`));
+
+        const reinstallTorchResult = await withResultAsync(() =>
+          this.runCommand(uvPath, reinstallTorchArgs, {
+            ...runProcessOptions,
+            env: { ...runProcessOptions.env, ...torchIndexEnv },
+            cwd: location,
+          })
+        );
+
+        if (reinstallTorchResult.isErr()) {
+          this.log.error(
+            c.red(`Failed to reinstall torch from custom index: ${reinstallTorchResult.error.message}\r\n`)
+          );
+          // torch was skipped during sync and this step may have uninstalled a previously-present build, so the venv
+          // is now without torch. Say so - the launcher's installed-version check only looks at the invokeai package,
+          // so the install would otherwise look normal and only fail at generation time.
+          this.log.error(
+            c.red(
+              'This environment now has no torch installed. Re-run the install - either without the custom PyTorch ' +
+                'index, or with one that carries the versions listed above.\r\n'
             )
           );
-        } else {
-          const reinstallTorchArgs = [
-            'pip',
-            'install',
-            '--python',
-            venvPath,
-            '--python-preference',
-            'only-managed',
-            // Pull the torch packages from the user-provided index *instead of* PyPI, not in addition to it. `--index`
-            // only *prepends* an index, so uv silently falls back to the default PyPI wheel when the custom index lacks
-            // the pinned (tag-stripped) version - installing the wrong backend with no error, the exact failure this
-            // feature prevents. `--index-url` makes the custom index the sole index, so a mismatch fails loudly. This is
-            // safe here because the step is `--no-deps` and requests only the torch-family packages.
-            `--index-url=${torchIndexOverride}`,
-            // The torch packages were skipped during sync; on a reinstall/update an older build may still be present,
-            // so force the install to guarantee the packages come from the custom index.
-            '--force-reinstall',
-            // Everything else is already installed by `uv sync`; only install the torch packages themselves.
-            '--no-deps',
-            '--compile-bytecode',
-            ...torchPackages.map(({ name, version }) => `${name}==${version}`),
-          ];
+          this.logRepairModeMessages();
+          this.updateStatus({
+            type: 'error',
+            error: {
+              message: 'Failed to reinstall torch from custom index',
+              context: serializeError(reinstallTorchResult.error),
+            },
+          });
+          return;
+        }
 
-          this.log.info(c.cyan('Installing torch from custom index...\r\n'));
-          this.log.info(redactForLog(`> VIRTUAL_ENV=${venvPath} ${uvPath} ${reinstallTorchArgs.join(' ')}\r\n`));
-
-          const reinstallTorchResult = await withResultAsync(() =>
-            this.runCommand(uvPath, reinstallTorchArgs, { ...runProcessOptions, cwd: location })
-          );
-
-          if (reinstallTorchResult.isErr()) {
-            this.log.error(
-              c.red(`Failed to reinstall torch from custom index: ${reinstallTorchResult.error.message}\r\n`)
-            );
-            this.updateStatus({
-              type: 'error',
-              error: {
-                message: 'Failed to reinstall torch from custom index',
-                context: serializeError(reinstallTorchResult.error),
-              },
-            });
-            return;
-          }
-
-          if (reinstallTorchResult.value === 'canceled') {
-            this.log.warn(c.yellow('Installation canceled\r\n'));
-            this.updateStatus({ type: 'canceled' });
-            return;
-          }
+        if (reinstallTorchResult.value === 'canceled') {
+          this.log.warn(c.yellow('Installation canceled\r\n'));
+          this.updateStatus({ type: 'canceled' });
+          return;
         }
       }
 
@@ -718,7 +746,14 @@ export class InstallManager {
         '--compile-bytecode',
       ];
 
-      const torchIndexUrl = torchIndexOverride ?? pins.torchIndexUrl[systemPlatform][torchPlatform];
+      // The override is *added in front of* the pinned index, not swapped for it. `--index` flags are searched in the
+      // order given, so torch resolves from the user's index while everything else still resolves from the
+      // platform-correct pinned index - an AMD user on Invoke 5.x who sets a custom index must not lose the ROCm index
+      // for the rest of the dependency graph.
+      const torchIndexUrl = pins.torchIndexUrl[systemPlatform][torchPlatform];
+      if (torchIndexOverride) {
+        installInvokeArgs.push(`--index=${torchIndexOverride}`);
+      }
       if (torchIndexUrl) {
         installInvokeArgs.push(`--index=${torchIndexUrl}`);
       }

--- a/src/main/install-manager.ts
+++ b/src/main/install-manager.ts
@@ -34,7 +34,7 @@ const shouldUseBootstrapInstall = (version: string): boolean => {
   return compare(version.replace(/^v/, ''), MIN_BOOTSTRAP_INSTALL_VERSION) >= 0;
 };
 
-const getInvokeExtras = (gpuType: GpuType, torchPlatform: 'cuda' | 'rocm' | 'cpu' | null): string[] => {
+const getInvokeExtras = (gpuType: GpuType, torchPlatform: 'cuda' | 'rocm' | 'xpu' | 'cpu' | null): string[] => {
   const extras: string[] = [];
 
   if (torchPlatform && process.platform !== 'darwin') {

--- a/src/main/torch-index.test.ts
+++ b/src/main/torch-index.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from 'vitest';
+
+import { buildCustomTorchInstallCommand, CUSTOM_TORCH_INDEX_NAME } from './torch-index';
+
+const VENV = '/home/user/invokeai/.venv';
+const PACKAGES = [
+  { name: 'torch', version: '2.7.1' },
+  { name: 'torchvision', version: '0.22.1' },
+];
+
+describe('buildCustomTorchInstallCommand', () => {
+  it('installs the requested packages at their tag-stripped versions', () => {
+    const { args } = buildCustomTorchInstallCommand(VENV, 'https://download.pytorch.org/whl/cu126', PACKAGES);
+    expect(args.slice(0, 2)).toEqual(['pip', 'install']);
+    expect(args).toContain('torch==2.7.1');
+    expect(args).toContain('torchvision==0.22.1');
+    expect(args).toContain('--python');
+    expect(args[args.indexOf('--python') + 1]).toBe(VENV);
+  });
+
+  it('adds the custom index alongside PyPI, pinned to the first-index strategy', () => {
+    const { args } = buildCustomTorchInstallCommand(VENV, 'https://download.pytorch.org/whl/cu126', PACKAGES);
+    expect(args).toContain(`--index=${CUSTOM_TORCH_INDEX_NAME}=https://download.pytorch.org/whl/cu126`);
+    expect(args[args.indexOf('--index-strategy') + 1]).toBe('first-index');
+    // `--index-url` / `--default-index` would make the custom index the *sole* index, which would also cut off torch's
+    // CUDA runtime dependencies (`nvidia-*-cu12`, `triton`) - those are published on PyPI.
+    expect(args.some((arg) => arg.startsWith('--index-url') || arg.startsWith('--default-index'))).toBe(false);
+  });
+
+  it('resolves dependencies so the CUDA runtime matches the custom torch build', () => {
+    // On Linux, torch's `nvidia-*-cu12` runtime is resolved from PyPI and pinned exactly by the torch wheel metadata.
+    // With `--no-deps`, `uv sync` would leave the lock's (e.g. cu128) runtime in place under a cu126 torch, and the
+    // install would still report success.
+    const { args } = buildCustomTorchInstallCommand(VENV, 'https://download.pytorch.org/whl/cu126', PACKAGES);
+    expect(args).not.toContain('--no-deps');
+  });
+
+  it('force-reinstalls only the torch packages, not every resolved dependency', () => {
+    const { args } = buildCustomTorchInstallCommand(VENV, 'https://download.pytorch.org/whl/cu126', PACKAGES);
+    expect(args).not.toContain('--force-reinstall');
+    const reinstalled = args.filter((arg, i) => args[i - 1] === '--reinstall-package');
+    expect(reinstalled).toEqual(['torch', 'torchvision']);
+  });
+
+  it('passes index credentials via the environment, never in argv', () => {
+    const { args, env } = buildCustomTorchInstallCommand(VENV, 'https://myuser:ghp_TOKEN@nexus.corp/simple', PACKAGES);
+    expect(args).toContain(`--index=${CUSTOM_TORCH_INDEX_NAME}=https://nexus.corp/simple`);
+    expect(args.join(' ')).not.toContain('ghp_TOKEN');
+    expect(args.join(' ')).not.toContain('myuser');
+    expect(env).toEqual({
+      UV_INDEX_INVOKE_CUSTOM_TORCH_USERNAME: 'myuser',
+      UV_INDEX_INVOKE_CUSTOM_TORCH_PASSWORD: 'ghp_TOKEN',
+    });
+  });
+
+  it('adds no environment for a credential-free index', () => {
+    const { env } = buildCustomTorchInstallCommand(VENV, 'https://download.pytorch.org/whl/cu126', PACKAGES);
+    expect(env).toEqual({});
+  });
+});

--- a/src/main/torch-index.ts
+++ b/src/main/torch-index.ts
@@ -1,0 +1,78 @@
+import type { LockedPackage } from '@/shared/pins';
+import { splitIndexUrlCredentials } from '@/shared/url';
+
+/**
+ * Builds the `uv pip install` invocation that installs the torch-family packages from a user-provided index.
+ *
+ * Extracted from the install manager so the argv construction - where the interesting failure modes live - is directly
+ * testable without spawning a PTY.
+ */
+
+/** The name we register the user's custom index under. uv derives its credential env vars from this name. */
+export const CUSTOM_TORCH_INDEX_NAME = 'invoke-custom-torch';
+
+/** `UV_INDEX_<NAME>_USERNAME` / `_PASSWORD`, where `<NAME>` is the index name uppercased with `-` replaced by `_`. */
+const CUSTOM_TORCH_INDEX_ENV_PREFIX = `UV_INDEX_${CUSTOM_TORCH_INDEX_NAME.toUpperCase().replaceAll('-', '_')}`;
+
+type CustomTorchInstallCommand = {
+  args: string[];
+  /** Extra environment for the command. Carries index credentials, which must never appear in argv. */
+  env: Record<string, string>;
+};
+
+export const buildCustomTorchInstallCommand = (
+  venvPath: string,
+  indexUrl: string,
+  packages: LockedPackage[]
+): CustomTorchInstallCommand => {
+  // Credentials go in the environment, not in argv, which is world-readable for the life of a multi-GB download.
+  const { url, username, password } = splitIndexUrlCredentials(indexUrl);
+
+  const args = [
+    'pip',
+    'install',
+    '--python',
+    venvPath,
+    '--python-preference',
+    'only-managed',
+    // Register the custom index *in addition to* PyPI rather than replacing it (`--index-url`/`--default-index`).
+    //
+    // uv's default index strategy is `first-index`: for a given package name it only considers versions from the first
+    // index that carries that name at all. So the torch family resolves solely from the custom index - if the pinned
+    // (tag-stripped) version is missing there, uv fails with "No solution found ... but not at the requested version"
+    // rather than silently substituting the PyPI wheel. (Verified against the bundled uv; `--index-url` behaves
+    // identically here, and is deprecated in favour of `--default-index`.)
+    //
+    // The difference that matters is everything torch *depends on*: on Linux, torch's CUDA runtime (`nvidia-*-cu12`,
+    // `triton`) is resolved from PyPI and pinned exactly by the torch wheel's metadata. Those must come from PyPI at
+    // the versions the custom build wants, otherwise we would leave e.g. a cu126 torch running against the lock's
+    // cu128 cuBLAS/cuDNN.
+    `--index=${CUSTOM_TORCH_INDEX_NAME}=${url}`,
+    // Be explicit rather than relying on the default: an ambient `UV_INDEX_STRATEGY=unsafe-best-match` (or a user
+    // `uv.toml`) would otherwise re-enable the silent PyPI fallback this whole step exists to avoid.
+    '--index-strategy',
+    'first-index',
+    '--compile-bytecode',
+  ];
+
+  // The torch packages were skipped during `uv sync`, but on a reinstall/update an older build may still be present.
+  // Force *only* those to be reinstalled - a blanket `--force-reinstall` would also rebuild every dependency uv
+  // resolves here, which is a large and pointless download.
+  for (const { name } of packages) {
+    args.push('--reinstall-package', name);
+  }
+
+  for (const { name, version } of packages) {
+    args.push(`${name}==${version}`);
+  }
+
+  const env: Record<string, string> = {};
+  if (username !== undefined) {
+    env[`${CUSTOM_TORCH_INDEX_ENV_PREFIX}_USERNAME`] = username;
+  }
+  if (password !== undefined) {
+    env[`${CUSTOM_TORCH_INDEX_ENV_PREFIX}_PASSWORD`] = password;
+  }
+
+  return { args, env };
+};

--- a/src/main/util.ts
+++ b/src/main/util.ts
@@ -76,7 +76,7 @@ export const getActivateVenvCommand = (installLocation: string): string => {
  * @param gpuType The GPU type
  * @returns The platform corresponding to the GPU type
  */
-export const getTorchPlatform = (gpuType: GpuType): 'cuda' | 'rocm' | 'cpu' => {
+export const getTorchPlatform = (gpuType: GpuType): 'cuda' | 'rocm' | 'xpu' | 'cpu' => {
   if (process.platform === 'darwin') {
     // macOS uses MPS, but we don't need to provide a separate option for this because pytorch doesn't have a separate index url for MPS
     return 'cpu';
@@ -84,6 +84,9 @@ export const getTorchPlatform = (gpuType: GpuType): 'cuda' | 'rocm' | 'cpu' => {
     switch (gpuType) {
       case 'amd':
         return 'rocm';
+      case 'intel':
+        // Intel's XPU backend. PyTorch publishes +xpu wheels for linux-x86_64 and windows-amd64 only.
+        return 'xpu';
       case 'nvidia<30xx':
       case 'nvidia>=30xx':
         return 'cuda';

--- a/src/renderer/features/InstallFlow/InstallFlowStepConfigure.tsx
+++ b/src/renderer/features/InstallFlow/InstallFlowStepConfigure.tsx
@@ -3,13 +3,11 @@ import { useStore } from '@nanostores/react';
 import { memo } from 'react';
 
 import { BodyContainer, BodyContent, BodyFooter, BodyHeader } from '@/renderer/common/layout';
-import {
-  InstallFlowStepConfigureCustomIndexUrl,
-  isCustomTorchIndexUrlInvalid,
-} from '@/renderer/features/InstallFlow/InstallFlowStepConfigureCustomIndexUrl';
+import { InstallFlowStepConfigureCustomIndexUrl } from '@/renderer/features/InstallFlow/InstallFlowStepConfigureCustomIndexUrl';
 import { InstallFlowStepConfigureGpuConfirm } from '@/renderer/features/InstallFlow/InstallFlowStepConfigureGpuConfirm';
 import { InstallFlowStepper } from '@/renderer/features/InstallFlow/InstallFlowStepper';
 import { installFlowApi } from '@/renderer/features/InstallFlow/state';
+import { isCustomTorchIndexUrlInvalid } from '@/shared/url';
 
 export const InstallFlowStepConfigure = memo(() => {
   const { gpuType, customTorchIndexUrl } = useStore(installFlowApi.$choices);

--- a/src/renderer/features/InstallFlow/InstallFlowStepConfigure.tsx
+++ b/src/renderer/features/InstallFlow/InstallFlowStepConfigure.tsx
@@ -3,26 +3,33 @@ import { useStore } from '@nanostores/react';
 import { memo } from 'react';
 
 import { BodyContainer, BodyContent, BodyFooter, BodyHeader } from '@/renderer/common/layout';
-import { InstallFlowStepConfigureGpuPicker } from '@/renderer/features/InstallFlow/InstallFlowStepConfigureGpuPicker';
+import {
+  InstallFlowStepConfigureCustomIndexUrl,
+  isCustomTorchIndexUrlInvalid,
+} from '@/renderer/features/InstallFlow/InstallFlowStepConfigureCustomIndexUrl';
+import { InstallFlowStepConfigureGpuConfirm } from '@/renderer/features/InstallFlow/InstallFlowStepConfigureGpuConfirm';
 import { InstallFlowStepper } from '@/renderer/features/InstallFlow/InstallFlowStepper';
 import { installFlowApi } from '@/renderer/features/InstallFlow/state';
 
 export const InstallFlowStepConfigure = memo(() => {
-  const { gpuType } = useStore(installFlowApi.$choices);
+  const { gpuType, customTorchIndexUrl } = useStore(installFlowApi.$choices);
+  const isNextDisabled = !gpuType || isCustomTorchIndexUrlInvalid(customTorchIndexUrl);
   return (
     <BodyContainer>
       <BodyHeader>
         <InstallFlowStepper />
       </BodyHeader>
       <BodyContent>
-        <InstallFlowStepConfigureGpuPicker />
+        <InstallFlowStepConfigureGpuConfirm />
+        <Divider />
+        <InstallFlowStepConfigureCustomIndexUrl />
       </BodyContent>
       <BodyFooter>
         <Button onClick={installFlowApi.prevStep} variant="link">
           Back
         </Button>
         <Divider orientation="vertical" />
-        <Button onClick={installFlowApi.nextStep} isDisabled={!gpuType} colorScheme="invokeYellow">
+        <Button onClick={installFlowApi.nextStep} isDisabled={isNextDisabled} colorScheme="invokeYellow">
           Next
         </Button>
       </BodyFooter>

--- a/src/renderer/features/InstallFlow/InstallFlowStepConfigure.tsx
+++ b/src/renderer/features/InstallFlow/InstallFlowStepConfigure.tsx
@@ -3,6 +3,7 @@ import { useStore } from '@nanostores/react';
 import { memo } from 'react';
 
 import { BodyContainer, BodyContent, BodyFooter, BodyHeader } from '@/renderer/common/layout';
+import { useSystemInfo } from '@/renderer/contexts/SystemInfoContext';
 import { InstallFlowStepConfigureCustomIndexUrl } from '@/renderer/features/InstallFlow/InstallFlowStepConfigureCustomIndexUrl';
 import { InstallFlowStepConfigureGpuConfirm } from '@/renderer/features/InstallFlow/InstallFlowStepConfigureGpuConfirm';
 import { InstallFlowStepper } from '@/renderer/features/InstallFlow/InstallFlowStepper';
@@ -11,6 +12,10 @@ import { isCustomTorchIndexUrlInvalid } from '@/shared/url';
 
 export const InstallFlowStepConfigure = memo(() => {
   const { gpuType, customTorchIndexUrl } = useStore(installFlowApi.$choices);
+  const { operatingSystem } = useSystemInfo();
+  // There is no macOS wheel on any PyTorch device index - macOS torch comes from PyPI and uses MPS - so an override
+  // there can only ever fail to resolve. Don't offer the field rather than letting someone paste the placeholder.
+  const isCustomIndexSupported = operatingSystem !== 'macOS';
   const isNextDisabled = !gpuType || isCustomTorchIndexUrlInvalid(customTorchIndexUrl);
   return (
     <BodyContainer>
@@ -19,8 +24,12 @@ export const InstallFlowStepConfigure = memo(() => {
       </BodyHeader>
       <BodyContent>
         <InstallFlowStepConfigureGpuConfirm />
-        <Divider />
-        <InstallFlowStepConfigureCustomIndexUrl />
+        {isCustomIndexSupported && (
+          <>
+            <Divider />
+            <InstallFlowStepConfigureCustomIndexUrl />
+          </>
+        )}
       </BodyContent>
       <BodyFooter>
         <Button onClick={installFlowApi.prevStep} variant="link">

--- a/src/renderer/features/InstallFlow/InstallFlowStepConfigureCustomIndexUrl.tsx
+++ b/src/renderer/features/InstallFlow/InstallFlowStepConfigureCustomIndexUrl.tsx
@@ -4,25 +4,7 @@ import type { ChangeEvent } from 'react';
 import { memo, useCallback } from 'react';
 
 import { installFlowApi } from '@/renderer/features/InstallFlow/state';
-
-const isHttpUrl = (value: string): boolean => {
-  try {
-    const url = new URL(value);
-    return url.protocol === 'http:' || url.protocol === 'https:';
-  } catch {
-    return false;
-  }
-};
-
-/**
- * A custom torch index URL is optional. When set, it must be a valid http(s) URL. Anything else (typos like
- * `htps://...`, a bare `cu126`, etc.) is rejected at entry so it doesn't surface minutes into an install as a
- * cryptic uv resolver error.
- */
-export const isCustomTorchIndexUrlInvalid = (value: string): boolean => {
-  const trimmed = value.trim();
-  return trimmed.length > 0 && !isHttpUrl(trimmed);
-};
+import { isCustomTorchIndexUrlInvalid } from '@/shared/url';
 
 export const InstallFlowStepConfigureCustomIndexUrl = memo(() => {
   const { customTorchIndexUrl } = useStore(installFlowApi.$choices);
@@ -43,6 +25,10 @@ export const InstallFlowStepConfigureCustomIndexUrl = memo(() => {
             <Text>
               Leave empty to use Invoke&apos;s defaults. When set, torch is installed from this index instead. Useful
               for e.g. cu126 on 20xx-series cards or ROCm on Windows. You are on your own with this override.
+            </Text>
+            <Text>
+              Note: on 20xx-series cards the xformers package is still built against Invoke&apos;s default CUDA build,
+              so a mismatched custom CUDA index can cause import errors or crashes.
             </Text>
           </Flex>
         }

--- a/src/renderer/features/InstallFlow/InstallFlowStepConfigureCustomIndexUrl.tsx
+++ b/src/renderer/features/InstallFlow/InstallFlowStepConfigureCustomIndexUrl.tsx
@@ -1,0 +1,72 @@
+import { Flex, FormControl, FormLabel, Heading, Input, Text, Tooltip } from '@invoke-ai/ui-library';
+import { useStore } from '@nanostores/react';
+import type { ChangeEvent } from 'react';
+import { memo, useCallback } from 'react';
+
+import { installFlowApi } from '@/renderer/features/InstallFlow/state';
+
+const isHttpUrl = (value: string): boolean => {
+  try {
+    const url = new URL(value);
+    return url.protocol === 'http:' || url.protocol === 'https:';
+  } catch {
+    return false;
+  }
+};
+
+/**
+ * A custom torch index URL is optional. When set, it must be a valid http(s) URL. Anything else (typos like
+ * `htps://...`, a bare `cu126`, etc.) is rejected at entry so it doesn't surface minutes into an install as a
+ * cryptic uv resolver error.
+ */
+export const isCustomTorchIndexUrlInvalid = (value: string): boolean => {
+  const trimmed = value.trim();
+  return trimmed.length > 0 && !isHttpUrl(trimmed);
+};
+
+export const InstallFlowStepConfigureCustomIndexUrl = memo(() => {
+  const { customTorchIndexUrl } = useStore(installFlowApi.$choices);
+
+  const onChange = useCallback((e: ChangeEvent<HTMLInputElement>) => {
+    installFlowApi.$choices.setKey('customTorchIndexUrl', e.target.value);
+  }, []);
+
+  const isInvalid = isCustomTorchIndexUrlInvalid(customTorchIndexUrl);
+
+  return (
+    <Flex flexDir="column" gap={2} w="full" maxW={96} alignItems="center">
+      <Heading size="sm">Custom PyTorch index (optional)</Heading>
+      <Tooltip
+        label={
+          <Flex flexDir="column" gap={1}>
+            <Text fontWeight="semibold">Override the PyTorch index for this installation.</Text>
+            <Text>
+              Leave empty to use Invoke&apos;s defaults. When set, torch is installed from this index instead. Useful
+              for e.g. cu126 on 20xx-series cards or ROCm on Windows. You are on your own with this override.
+            </Text>
+          </Flex>
+        }
+      >
+        <FormControl isInvalid={isInvalid} flexDir="column" gap={1}>
+          <FormLabel m={0} fontWeight="normal" fontSize="md">
+            PyTorch index URL
+          </FormLabel>
+          <Input
+            value={customTorchIndexUrl}
+            placeholder="https://download.pytorch.org/whl/cu126"
+            onChange={onChange}
+            variant="outline"
+            size="md"
+            isInvalid={isInvalid}
+          />
+        </FormControl>
+      </Tooltip>
+      {isInvalid && (
+        <Text fontSize="md" color="error.300">
+          Enter a valid http(s) URL.
+        </Text>
+      )}
+    </Flex>
+  );
+});
+InstallFlowStepConfigureCustomIndexUrl.displayName = 'InstallFlowStepConfigureCustomIndexUrl';

--- a/src/renderer/features/InstallFlow/InstallFlowStepConfigureCustomIndexUrl.tsx
+++ b/src/renderer/features/InstallFlow/InstallFlowStepConfigureCustomIndexUrl.tsx
@@ -23,8 +23,12 @@ export const InstallFlowStepConfigureCustomIndexUrl = memo(() => {
           <Flex flexDir="column" gap={1}>
             <Text fontWeight="semibold">Override the PyTorch index for this installation.</Text>
             <Text>
-              Leave empty to use Invoke&apos;s defaults. When set, torch is installed from this index instead. Useful
-              for e.g. cu126 on 20xx-series cards or ROCm on Windows. You are on your own with this override.
+              Leave empty to use Invoke&apos;s defaults. When set, torch is installed from this index instead - useful
+              for e.g. a different CUDA build than the one Invoke ships. You are on your own with this override.
+            </Text>
+            <Text>
+              The index must carry the exact torch versions Invoke&apos;s lockfile pins, only built differently. If it
+              doesn&apos;t, the install fails rather than quietly falling back.
             </Text>
             <Text>
               Note: on 20xx-series cards the xformers package is still built against Invoke&apos;s default CUDA build,

--- a/src/renderer/features/InstallFlow/InstallFlowStepConfigureGpuConfirm.tsx
+++ b/src/renderer/features/InstallFlow/InstallFlowStepConfigureGpuConfirm.tsx
@@ -1,0 +1,164 @@
+import { Button, ButtonGroup, Flex, Heading, Spinner, Text } from '@invoke-ai/ui-library';
+import { useStore } from '@nanostores/react';
+import { memo, useCallback, useEffect } from 'react';
+
+import { InstallFlowStepConfigureGpuPicker } from '@/renderer/features/InstallFlow/InstallFlowStepConfigureGpuPicker';
+import { installFlowApi } from '@/renderer/features/InstallFlow/state';
+import type { GpuBackend, GpuType } from '@/shared/types';
+import { GPU_TYPE_MAP } from '@/shared/types';
+
+/** Human-readable description of a detected backend, for the confirmation prompt. */
+const BACKEND_LABEL: Record<GpuBackend, string> = {
+  cuda: 'an NVIDIA GPU (CUDA)',
+  rocm: 'an AMD GPU (ROCm)',
+  metal: 'a Mac GPU (Metal / MPS)',
+  cpu: 'no dedicated GPU (CPU only)',
+};
+
+/** Non-CUDA backends map straight to a GPU type. CUDA is handled separately because the generation is ambiguous. */
+const BACKEND_TO_GPU_TYPE: Record<Exclude<GpuBackend, 'cuda'>, GpuType> = {
+  rocm: 'amd',
+  metal: 'nogpu',
+  cpu: 'nogpu',
+};
+
+export const InstallFlowStepConfigureGpuConfirm = memo(() => {
+  const detection = useStore(installFlowApi.$gpuDetection);
+  const status = useStore(installFlowApi.$gpuDetectionStatus);
+  const phase = useStore(installFlowApi.$gpuConfirmPhase);
+
+  // Kick off detection once when this step first mounts (idempotent - the action guards against concurrent runs).
+  useEffect(() => {
+    if (installFlowApi.$gpuDetectionStatus.get() === 'idle') {
+      void installFlowApi.detectGpu();
+    }
+  }, []);
+
+  const onConfirmYes = useCallback(() => {
+    const result = installFlowApi.$gpuDetection.get();
+    if (!result) {
+      return;
+    }
+    if (result.backend === 'cuda') {
+      // We can't auto-detect the Nvidia generation, so force a tier choice before continuing.
+      installFlowApi.$choices.setKey('gpuType', null);
+      installFlowApi.$gpuConfirmPhase.set('nvidia-tier');
+    } else {
+      installFlowApi.$choices.setKey('gpuType', BACKEND_TO_GPU_TYPE[result.backend]);
+      installFlowApi.$gpuConfirmPhase.set('done');
+    }
+  }, []);
+
+  const onConfirmNo = useCallback(() => {
+    installFlowApi.$choices.setKey('gpuType', null);
+    installFlowApi.$gpuConfirmPhase.set('manual');
+  }, []);
+
+  // Return from the manual picker to the auto-detected result, so auto-detect is never a dead end.
+  const onBackToAutodetect = useCallback(() => {
+    installFlowApi.$choices.setKey('gpuType', null);
+    installFlowApi.$gpuConfirmPhase.set('confirm');
+  }, []);
+
+  const onRetryDetect = useCallback(() => {
+    installFlowApi.$choices.setKey('gpuType', null);
+    installFlowApi.$gpuConfirmPhase.set('confirm');
+    void installFlowApi.detectGpu();
+  }, []);
+
+  if (status === 'idle' || status === 'detecting') {
+    return (
+      <Flex flexDir="column" gap={3} alignItems="center">
+        <Spinner />
+        <Text fontSize="md">Detecting your hardware…</Text>
+      </Flex>
+    );
+  }
+
+  // Detection failed - fall back to the manual picker, but keep a way to retry auto-detect.
+  if (status === 'error' || !detection) {
+    return (
+      <Flex flexDir="column" gap={3} alignItems="center" w="full">
+        <Text fontSize="md">We couldn&apos;t detect your GPU automatically. Please choose:</Text>
+        <InstallFlowStepConfigureGpuPicker />
+        <Button variant="link" onClick={onRetryDetect}>
+          Try auto-detect again
+        </Button>
+      </Flex>
+    );
+  }
+
+  if (phase === 'manual') {
+    return (
+      <Flex flexDir="column" gap={3} alignItems="center" w="full">
+        <InstallFlowStepConfigureGpuPicker />
+        <Button variant="link" onClick={onBackToAutodetect}>
+          Use the auto-detected result instead
+        </Button>
+      </Flex>
+    );
+  }
+
+  if (phase === 'nvidia-tier') {
+    return <NvidiaTierPicker onBack={onConfirmNo} />;
+  }
+
+  if (phase === 'done') {
+    return <DetectedSummary onChange={onConfirmNo} />;
+  }
+
+  // phase === 'confirm'
+  return (
+    <Flex flexDir="column" gap={4} alignItems="center" maxW={112}>
+      <Heading size="sm">We detected {BACKEND_LABEL[detection.backend]}.</Heading>
+      <Text fontSize="md" textAlign="center">
+        Is this correct?
+      </Text>
+      <ButtonGroup variant="outline">
+        <Button colorScheme="invokeYellow" onClick={onConfirmYes}>
+          Yes, that&apos;s right
+        </Button>
+        <Button onClick={onConfirmNo}>No, let me choose</Button>
+      </ButtonGroup>
+    </Flex>
+  );
+});
+InstallFlowStepConfigureGpuConfirm.displayName = 'InstallFlowStepConfigureGpuConfirm';
+
+const NvidiaTierPicker = memo(({ onBack }: { onBack: () => void }) => {
+  const { gpuType } = useStore(installFlowApi.$choices);
+  const onClickOld = useCallback(() => installFlowApi.$choices.setKey('gpuType', 'nvidia<30xx'), []);
+  const onClickNew = useCallback(() => installFlowApi.$choices.setKey('gpuType', 'nvidia>=30xx'), []);
+  return (
+    <Flex flexDir="column" gap={3} alignItems="center">
+      <Heading size="sm">Which NVIDIA generation do you have?</Heading>
+      <ButtonGroup variant="outline">
+        <Button colorScheme={gpuType === 'nvidia<30xx' ? 'invokeBlue' : 'base'} onClick={onClickOld}>
+          {GPU_TYPE_MAP['nvidia<30xx']}
+        </Button>
+        <Button colorScheme={gpuType === 'nvidia>=30xx' ? 'invokeBlue' : 'base'} onClick={onClickNew}>
+          {GPU_TYPE_MAP['nvidia>=30xx']}
+        </Button>
+      </ButtonGroup>
+      <Button variant="link" onClick={onBack}>
+        Pick a different GPU
+      </Button>
+    </Flex>
+  );
+});
+NvidiaTierPicker.displayName = 'NvidiaTierPicker';
+
+const DetectedSummary = memo(({ onChange }: { onChange: () => void }) => {
+  const { gpuType } = useStore(installFlowApi.$choices);
+  return (
+    <Flex flexDir="column" gap={3} alignItems="center">
+      <Text fontSize="md">
+        Using <strong>{gpuType ? GPU_TYPE_MAP[gpuType] : ''}</strong>.
+      </Text>
+      <Button variant="link" onClick={onChange}>
+        Change
+      </Button>
+    </Flex>
+  );
+});
+DetectedSummary.displayName = 'DetectedSummary';

--- a/src/renderer/features/InstallFlow/InstallFlowStepConfigureGpuConfirm.tsx
+++ b/src/renderer/features/InstallFlow/InstallFlowStepConfigureGpuConfirm.tsx
@@ -34,6 +34,15 @@ export const InstallFlowStepConfigureGpuConfirm = memo(() => {
     }
   }, []);
 
+  // On macOS the only sane answer to "we detected a Mac GPU (Metal / MPS)" is yes, so skip the confirmation prompt and
+  // go straight to the summary. The user can still change it from there.
+  useEffect(() => {
+    if (status === 'done' && detection?.backend === 'metal' && phase === 'confirm') {
+      installFlowApi.$choices.setKey('gpuType', BACKEND_TO_GPU_TYPE.metal);
+      installFlowApi.$gpuConfirmPhase.set('done');
+    }
+  }, [status, detection, phase]);
+
   const onConfirmYes = useCallback(() => {
     const result = installFlowApi.$gpuDetection.get();
     if (!result) {
@@ -107,10 +116,19 @@ export const InstallFlowStepConfigureGpuConfirm = memo(() => {
     return <DetectedSummary onChange={onConfirmNo} />;
   }
 
+  // A discrete AMD GPU on Windows is reported as the CPU backend (no ROCm on Windows), so give it an honest message
+  // rather than the misleading "no dedicated GPU".
+  const isWindowsAmd = detection.backend === 'cpu' && detection.vendor === 'amd';
+  const detectionHeading = isWindowsAmd
+    ? 'We detected an AMD GPU, but ROCm is not supported on Windows, so Invoke will use your CPU.'
+    : `We detected ${BACKEND_LABEL[detection.backend]}.`;
+
   // phase === 'confirm'
   return (
     <Flex flexDir="column" gap={4} alignItems="center" maxW={112}>
-      <Heading size="sm">We detected {BACKEND_LABEL[detection.backend]}.</Heading>
+      <Heading size="sm" textAlign="center">
+        {detectionHeading}
+      </Heading>
       <Text fontSize="md" textAlign="center">
         Is this correct?
       </Text>

--- a/src/renderer/features/InstallFlow/InstallFlowStepConfigureGpuConfirm.tsx
+++ b/src/renderer/features/InstallFlow/InstallFlowStepConfigureGpuConfirm.tsx
@@ -3,8 +3,8 @@ import { useStore } from '@nanostores/react';
 import { memo, useCallback, useEffect } from 'react';
 
 import { InstallFlowStepConfigureGpuPicker } from '@/renderer/features/InstallFlow/InstallFlowStepConfigureGpuPicker';
-import { installFlowApi } from '@/renderer/features/InstallFlow/state';
-import type { GpuBackend, GpuType } from '@/shared/types';
+import { BACKEND_TO_GPU_TYPE, installFlowApi } from '@/renderer/features/InstallFlow/state';
+import type { GpuBackend } from '@/shared/types';
 import { GPU_TYPE_MAP } from '@/shared/types';
 
 /** Human-readable description of a detected backend, for the confirmation prompt. */
@@ -13,13 +13,6 @@ const BACKEND_LABEL: Record<GpuBackend, string> = {
   rocm: 'an AMD GPU (ROCm)',
   metal: 'a Mac GPU (Metal / MPS)',
   cpu: 'no dedicated GPU (CPU only)',
-};
-
-/** Non-CUDA backends map straight to a GPU type. CUDA is handled separately because the generation is ambiguous. */
-const BACKEND_TO_GPU_TYPE: Record<Exclude<GpuBackend, 'cuda'>, GpuType> = {
-  rocm: 'amd',
-  metal: 'nogpu',
-  cpu: 'nogpu',
 };
 
 export const InstallFlowStepConfigureGpuConfirm = memo(() => {
@@ -33,15 +26,6 @@ export const InstallFlowStepConfigureGpuConfirm = memo(() => {
       void installFlowApi.detectGpu();
     }
   }, []);
-
-  // On macOS the only sane answer to "we detected a Mac GPU (Metal / MPS)" is yes, so skip the confirmation prompt and
-  // go straight to the summary. The user can still change it from there.
-  useEffect(() => {
-    if (status === 'done' && detection?.backend === 'metal' && phase === 'confirm') {
-      installFlowApi.$choices.setKey('gpuType', BACKEND_TO_GPU_TYPE.metal);
-      installFlowApi.$gpuConfirmPhase.set('done');
-    }
-  }, [status, detection, phase]);
 
   const onConfirmYes = useCallback(() => {
     const result = installFlowApi.$gpuDetection.get();
@@ -113,14 +97,14 @@ export const InstallFlowStepConfigureGpuConfirm = memo(() => {
   }
 
   if (phase === 'done') {
-    return <DetectedSummary onChange={onConfirmNo} />;
+    return <DetectedSummary backend={detection.backend} onChange={onConfirmNo} />;
   }
 
-  // A discrete AMD GPU on Windows is reported as the CPU backend (no ROCm on Windows), so give it an honest message
-  // rather than the misleading "no dedicated GPU".
-  const isWindowsAmd = detection.backend === 'cpu' && detection.vendor === 'amd';
-  const detectionHeading = isWindowsAmd
-    ? 'We detected an AMD GPU, but ROCm is not supported on Windows, so Invoke will use your CPU.'
+  // AMD hardware that cannot use ROCm - a discrete card on Windows, or integrated Radeon graphics with no ROCm build -
+  // is reported as the CPU backend. Use the probe's own explanation rather than the misleading "no dedicated GPU".
+  const isAmdWithoutRocm = detection.backend === 'cpu' && detection.vendor === 'amd';
+  const detectionHeading = isAmdWithoutRocm
+    ? `${detection.decision}.`
     : `We detected ${BACKEND_LABEL[detection.backend]}.`;
 
   // phase === 'confirm'
@@ -166,12 +150,15 @@ const NvidiaTierPicker = memo(({ onBack }: { onBack: () => void }) => {
 });
 NvidiaTierPicker.displayName = 'NvidiaTierPicker';
 
-const DetectedSummary = memo(({ onChange }: { onChange: () => void }) => {
+const DetectedSummary = memo(({ backend, onChange }: { backend: GpuBackend; onChange: () => void }) => {
   const { gpuType } = useStore(installFlowApi.$choices);
+  // A Mac maps to the same `nogpu` type as a machine with no GPU at all (torch for macOS comes from the default index
+  // either way), so the GPU-type label would read "No dedicated GPU" to an M3 Max owner. Name what we detected instead.
+  const label = backend === 'metal' ? 'Mac GPU (Metal / MPS)' : gpuType ? GPU_TYPE_MAP[gpuType] : '';
   return (
     <Flex flexDir="column" gap={3} alignItems="center">
       <Text fontSize="md">
-        Using <strong>{gpuType ? GPU_TYPE_MAP[gpuType] : ''}</strong>.
+        Using <strong>{label}</strong>.
       </Text>
       <Button variant="link" onClick={onChange}>
         Change

--- a/src/renderer/features/InstallFlow/InstallFlowStepConfigureGpuConfirm.tsx
+++ b/src/renderer/features/InstallFlow/InstallFlowStepConfigureGpuConfirm.tsx
@@ -11,6 +11,7 @@ import { GPU_TYPE_MAP } from '@/shared/types';
 const BACKEND_LABEL: Record<GpuBackend, string> = {
   cuda: 'an NVIDIA GPU (CUDA)',
   rocm: 'an AMD GPU (ROCm)',
+  xpu: 'an Intel Arc GPU (XPU)',
   metal: 'a Mac GPU (Metal / MPS)',
   cpu: 'no dedicated GPU (CPU only)',
 };
@@ -100,10 +101,12 @@ export const InstallFlowStepConfigureGpuConfirm = memo(() => {
     return <DetectedSummary backend={detection.backend} onChange={onConfirmNo} />;
   }
 
-  // AMD hardware that cannot use ROCm - a discrete card on Windows, or integrated Radeon graphics with no ROCm build -
-  // is reported as the CPU backend. Use the probe's own explanation rather than the misleading "no dedicated GPU".
-  const isAmdWithoutRocm = detection.backend === 'cpu' && detection.vendor === 'amd';
-  const detectionHeading = isAmdWithoutRocm
+  // Hardware we recognised but whose accelerated backend is unusable - a Radeon on Windows, integrated Radeon graphics
+  // with no ROCm build, Intel graphics older than Arc - is reported as the CPU backend. Use the probe's own
+  // explanation rather than the misleading "no dedicated GPU".
+  const isUnusableVendorGpu =
+    detection.backend === 'cpu' && (detection.vendor === 'amd' || detection.vendor === 'intel');
+  const detectionHeading = isUnusableVendorGpu
     ? `${detection.decision}.`
     : `We detected ${BACKEND_LABEL[detection.backend]}.`;
 

--- a/src/renderer/features/InstallFlow/InstallFlowStepConfigureGpuPicker.tsx
+++ b/src/renderer/features/InstallFlow/InstallFlowStepConfigureGpuPicker.tsx
@@ -13,10 +13,12 @@ export const InstallFlowStepConfigureGpuPicker = memo(() => {
   return (
     <>
       <Heading>What GPU do you have?</Heading>
-      <ButtonGroup variant="outline">
+      <ButtonGroup variant="outline" flexWrap="wrap" justifyContent="center" rowGap={2}>
         <GpuButton type="nvidia<30xx" />
         <GpuButton type="nvidia>=30xx" />
         <GpuButton type="amd" />
+        {/* PyTorch publishes +xpu wheels for linux-x86_64 and windows-amd64 only - on a Mac, Intel means Metal or CPU. */}
+        {operatingSystem !== 'macOS' && <GpuButton type="intel" />}
         <GpuButton type="nogpu" />
       </ButtonGroup>
       {operatingSystem === 'macOS' && <Text fontSize="md">Tip: Macs usually have no dedicated GPU.</Text>}

--- a/src/renderer/features/InstallFlow/InstallFlowStepReview.tsx
+++ b/src/renderer/features/InstallFlow/InstallFlowStepReview.tsx
@@ -35,7 +35,8 @@ const GPU_LABEL_MAP: Record<GpuType, string> = {
 };
 
 export const InstallFlowStepReview = memo(() => {
-  const { dirDetails, gpuType, release, repairMode } = useStore(installFlowApi.$choices);
+  const { dirDetails, gpuType, release, repairMode, customTorchIndexUrl } = useStore(installFlowApi.$choices);
+  const trimmedCustomTorchIndexUrl = customTorchIndexUrl.trim();
   const installType = useStore(installFlowApi.$installType);
 
   const onChangeRepairMode = useCallback((e: ChangeEvent<HTMLInputElement>) => {
@@ -82,6 +83,13 @@ export const InstallFlowStepReview = memo(() => {
               You have <Strong>{GPU_LABEL_MAP[gpuType]}.</Strong>
             </Text>
           </ListItem>
+          {trimmedCustomTorchIndexUrl && (
+            <ListItem>
+              <Text fontSize="md">
+                Torch will be installed from a <Strong>custom index</Strong>: {trimmedCustomTorchIndexUrl}
+              </Text>
+            </ListItem>
+          )}
         </UnorderedList>
         <Spacer />
       </BodyContent>

--- a/src/renderer/features/InstallFlow/InstallFlowStepReview.tsx
+++ b/src/renderer/features/InstallFlow/InstallFlowStepReview.tsx
@@ -32,6 +32,7 @@ const GPU_LABEL_MAP: Record<GpuType, string> = {
   'nvidia<30xx': 'a Nvidia 20xx or older GPU',
   'nvidia>=30xx': 'a Nvidia 30xx or newer GPU',
   amd: 'an AMD GPU',
+  intel: 'an Intel Arc GPU',
   nogpu: 'no GPU',
 };
 

--- a/src/renderer/features/InstallFlow/InstallFlowStepReview.tsx
+++ b/src/renderer/features/InstallFlow/InstallFlowStepReview.tsx
@@ -26,6 +26,7 @@ import {
 import { InstallFlowStepper } from '@/renderer/features/InstallFlow/InstallFlowStepper';
 import { installFlowApi } from '@/renderer/features/InstallFlow/state';
 import type { GpuType } from '@/shared/types';
+import { redactUrlCredentials } from '@/shared/url';
 
 const GPU_LABEL_MAP: Record<GpuType, string> = {
   'nvidia<30xx': 'a Nvidia 20xx or older GPU',
@@ -86,7 +87,8 @@ export const InstallFlowStepReview = memo(() => {
           {trimmedCustomTorchIndexUrl && (
             <ListItem>
               <Text fontSize="md">
-                Torch will be installed from a <Strong>custom index</Strong>: {trimmedCustomTorchIndexUrl}
+                Torch will be installed from a <Strong>custom index</Strong>:{' '}
+                {redactUrlCredentials(trimmedCustomTorchIndexUrl)}
               </Text>
             </ListItem>
           )}

--- a/src/renderer/features/InstallFlow/state.ts
+++ b/src/renderer/features/InstallFlow/state.ts
@@ -10,15 +10,20 @@ import { withResultAsync } from '@/lib/result';
 import { DEFAULT_XTERM_OPTIONS, STATUS_POLL_INTERVAL_MS } from '@/renderer/constants';
 import { $latestGHReleases } from '@/renderer/services/gh';
 import { emitter, ipc } from '@/renderer/services/ipc';
-import {
-  $installDirDetails,
-  $operatingSystem,
-  persistedStoreApi,
-  syncInstallDirDetails,
-} from '@/renderer/services/store';
-import type { DirDetails, GpuType, InstallProcessStatus, InstallType, WithTimestamp } from '@/shared/types';
+import { $installDirDetails, persistedStoreApi, syncInstallDirDetails } from '@/renderer/services/store';
+import type {
+  DirDetails,
+  GpuDetectionResult,
+  GpuType,
+  InstallProcessStatus,
+  InstallType,
+  WithTimestamp,
+} from '@/shared/types';
 
 const steps = ['Location', 'Version', 'Configure', 'Review', 'Install'] as const;
+
+/** The sub-views of the GPU confirmation flow in the Configure step. */
+export type GpuConfirmPhase = 'confirm' | 'nvidia-tier' | 'manual' | 'done';
 
 const $choices = map<{
   dirDetails: DirDetails | null;
@@ -33,16 +38,23 @@ const $choices = map<{
     | { type: 'manual'; version: string }
     | null;
   repairMode: boolean;
+  customTorchIndexUrl: string;
 }>({
   dirDetails: null,
   gpuType: null,
   release: null,
   repairMode: false,
+  customTorchIndexUrl: '',
 });
 
 const $activeStep = atom(0);
 const $isStarted = atom(false);
 const $isFinished = atom(false);
+const $gpuDetection = atom<GpuDetectionResult | null>(null);
+const $gpuDetectionStatus = atom<'idle' | 'detecting' | 'done' | 'error'>('idle');
+// Which sub-view of the GPU confirmation step is showing. Kept in the store (not component state) so it survives
+// navigating away from and back to the Configure step - otherwise returning would drop back to the manual picker.
+const $gpuConfirmPhase = atom<GpuConfirmPhase>('confirm');
 const $installType = computed($choices, ({ dirDetails, release }): InstallType | null => {
   if (!release) {
     return null;
@@ -83,6 +95,25 @@ export const installFlowApi = {
   $activeStep: $activeStep as ReadableAtom<number>,
   $isStarted: $isStarted as ReadableAtom<boolean>,
   $isFinished: $isFinished as ReadableAtom<boolean>,
+  $gpuDetection: $gpuDetection as ReadableAtom<GpuDetectionResult | null>,
+  $gpuDetectionStatus: $gpuDetectionStatus as ReadableAtom<'idle' | 'detecting' | 'done' | 'error'>,
+  // Mutable - the Configure step reads and writes the current sub-view.
+  $gpuConfirmPhase,
+  detectGpu: async () => {
+    if ($gpuDetectionStatus.get() === 'detecting') {
+      return;
+    }
+    $gpuDetectionStatus.set('detecting');
+    const result = await withResultAsync(() => emitter.invoke('util:detect-gpu'));
+    if (result.isOk()) {
+      $gpuDetection.set(result.value);
+      $gpuDetectionStatus.set('done');
+    } else {
+      // Detection is advisory; on failure we fall back to the manual GPU picker in the Configure step.
+      $gpuDetection.set(null);
+      $gpuDetectionStatus.set('error');
+    }
+  },
   nextStep: () => {
     const currentStep = $activeStep.get();
     $activeStep.set(clamp(currentStep + 1, 0, installFlowApi.steps.length - 1));
@@ -97,7 +128,11 @@ export const installFlowApi = {
       gpuType: null,
       release: null,
       repairMode: false,
+      customTorchIndexUrl: '',
     });
+    $gpuDetection.set(null);
+    $gpuDetectionStatus.set('idle');
+    $gpuConfirmPhase.set('confirm');
     $activeStep.set(0);
     $isStarted.set(true);
   },
@@ -107,17 +142,29 @@ export const installFlowApi = {
       gpuType: null,
       release: null,
       repairMode: false,
+      customTorchIndexUrl: '',
     });
+    $gpuDetection.set(null);
+    $gpuDetectionStatus.set('idle');
+    $gpuConfirmPhase.set('confirm');
     $activeStep.set(0);
     $isStarted.set(false);
   },
   startInstall: () => {
-    const { dirDetails, gpuType, release, repairMode } = $choices.get();
+    const { dirDetails, gpuType, release, repairMode, customTorchIndexUrl } = $choices.get();
     if (!dirDetails || !dirDetails.canInstall || !release || !gpuType) {
       return;
     }
     initializeTerminal();
-    emitter.invoke('install-process:start-install', dirDetails.path, gpuType, release.version, repairMode);
+    const trimmedCustomTorchIndexUrl = customTorchIndexUrl.trim() || undefined;
+    emitter.invoke(
+      'install-process:start-install',
+      dirDetails.path,
+      gpuType,
+      release.version,
+      trimmedCustomTorchIndexUrl,
+      repairMode
+    );
     installFlowApi.nextStep();
   },
   cancelInstall: async () => {
@@ -162,19 +209,6 @@ const syncReleaseChoiceWithLatestReleases = () => {
 
 $latestGHReleases.listen(syncReleaseChoiceWithLatestReleases);
 $choices.listen(syncReleaseChoiceWithLatestReleases);
-
-const syncGpuTypeWithOperatingSystem = () => {
-  if ($choices.get().gpuType) {
-    return;
-  }
-
-  const operatingSystem = $operatingSystem.get();
-
-  $choices.setKey('gpuType', operatingSystem === 'macOS' ? 'nogpu' : 'nvidia>=30xx');
-};
-
-$operatingSystem.listen(syncGpuTypeWithOperatingSystem);
-$choices.listen(syncGpuTypeWithOperatingSystem);
 
 export const $installProcessStatus = atom<WithTimestamp<InstallProcessStatus>>({
   type: 'uninitialized',

--- a/src/renderer/features/InstallFlow/state.ts
+++ b/src/renderer/features/InstallFlow/state.ts
@@ -23,7 +23,7 @@ import type {
 const steps = ['Location', 'Version', 'Configure', 'Review', 'Install'] as const;
 
 /** The sub-views of the GPU confirmation flow in the Configure step. */
-export type GpuConfirmPhase = 'confirm' | 'nvidia-tier' | 'manual' | 'done';
+type GpuConfirmPhase = 'confirm' | 'nvidia-tier' | 'manual' | 'done';
 
 const $choices = map<{
   dirDetails: DirDetails | null;

--- a/src/renderer/features/InstallFlow/state.ts
+++ b/src/renderer/features/InstallFlow/state.ts
@@ -34,6 +34,7 @@ type GpuConfirmPhase = 'confirm' | 'nvidia-tier' | 'manual' | 'done';
  */
 export const BACKEND_TO_GPU_TYPE: Record<Exclude<GpuBackend, 'cuda'>, GpuType> = {
   rocm: 'amd',
+  xpu: 'intel',
   metal: 'nogpu',
   cpu: 'nogpu',
 };

--- a/src/renderer/features/InstallFlow/state.ts
+++ b/src/renderer/features/InstallFlow/state.ts
@@ -13,6 +13,7 @@ import { emitter, ipc } from '@/renderer/services/ipc';
 import { $installDirDetails, persistedStoreApi, syncInstallDirDetails } from '@/renderer/services/store';
 import type {
   DirDetails,
+  GpuBackend,
   GpuDetectionResult,
   GpuType,
   InstallProcessStatus,
@@ -24,6 +25,18 @@ const steps = ['Location', 'Version', 'Configure', 'Review', 'Install'] as const
 
 /** The sub-views of the GPU confirmation flow in the Configure step. */
 type GpuConfirmPhase = 'confirm' | 'nvidia-tier' | 'manual' | 'done';
+
+/**
+ * Non-CUDA backends map straight to a GPU type. CUDA is handled separately because the generation is ambiguous.
+ *
+ * Both `metal` and `cpu` map to `nogpu`: the launcher's GPU types select a torch index, and macOS torch (MPS included)
+ * comes from the default index either way.
+ */
+export const BACKEND_TO_GPU_TYPE: Record<Exclude<GpuBackend, 'cuda'>, GpuType> = {
+  rocm: 'amd',
+  metal: 'nogpu',
+  cpu: 'nogpu',
+};
 
 const $choices = map<{
   dirDetails: DirDetails | null;
@@ -55,6 +68,9 @@ const $gpuDetectionStatus = atom<'idle' | 'detecting' | 'done' | 'error'>('idle'
 // Which sub-view of the GPU confirmation step is showing. Kept in the store (not component state) so it survives
 // navigating away from and back to the Configure step - otherwise returning would drop back to the manual picker.
 const $gpuConfirmPhase = atom<GpuConfirmPhase>('confirm');
+// Incremented for every detection run (and whenever the flow is reset) so an in-flight run that has been superseded
+// can drop its result instead of writing it into fresh state.
+let gpuDetectionRunId = 0;
 const $installType = computed($choices, ({ dirDetails, release }): InstallType | null => {
   if (!release) {
     return null;
@@ -103,11 +119,23 @@ export const installFlowApi = {
     if ($gpuDetectionStatus.get() === 'detecting') {
       return;
     }
+    const runId = ++gpuDetectionRunId;
     $gpuDetectionStatus.set('detecting');
     const result = await withResultAsync(() => emitter.invoke('util:detect-gpu'));
+    // `beginFlow`/`cancelFlow` reset the status to 'idle' while a probe may still be in flight, which lets a second run
+    // start. Drop the superseded run's result rather than letting it stomp the fresh state.
+    if (runId !== gpuDetectionRunId) {
+      return;
+    }
     if (result.isOk()) {
       $gpuDetection.set(result.value);
       $gpuDetectionStatus.set('done');
+      if (result.value.backend === 'metal') {
+        // On macOS "we detected a Mac GPU (Metal / MPS) - is this correct?" has exactly one sane answer, so skip the
+        // confirmation. Done here rather than in a render effect, which would flash the prompt for a frame first.
+        $choices.setKey('gpuType', BACKEND_TO_GPU_TYPE.metal);
+        $gpuConfirmPhase.set('done');
+      }
     } else {
       // Detection is advisory; on failure we fall back to the manual GPU picker in the Configure step.
       $gpuDetection.set(null);
@@ -130,6 +158,7 @@ export const installFlowApi = {
       repairMode: false,
       customTorchIndexUrl: '',
     });
+    gpuDetectionRunId++;
     $gpuDetection.set(null);
     $gpuDetectionStatus.set('idle');
     $gpuConfirmPhase.set('confirm');
@@ -144,6 +173,7 @@ export const installFlowApi = {
       repairMode: false,
       customTorchIndexUrl: '',
     });
+    gpuDetectionRunId++;
     $gpuDetection.set(null);
     $gpuDetectionStatus.set('idle');
     $gpuConfirmPhase.set('confirm');

--- a/src/shared/pins.test.ts
+++ b/src/shared/pins.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
-import { getInvokeReleaseInstallFiles, getPins } from './pins';
+import { getInvokeReleaseInstallFiles, getPins, getTorchPackagesFromLock } from './pins';
 
 const pins = {
   python: '3.12',
@@ -63,5 +63,118 @@ describe('pins', () => {
     expect(fetchMock).toHaveBeenCalledWith('https://raw.githubusercontent.com/invoke-ai/InvokeAI/v6.13.0/pins.json');
     expect(fetchMock).toHaveBeenCalledWith('https://cdn.jsdelivr.net/gh/invoke-ai/InvokeAI@v6.13.0/pins.json');
     expect(warnSpy).toHaveBeenCalledOnce();
+  });
+});
+
+describe('getTorchPackagesFromLock', () => {
+  // Mirrors the real Invoke uv.lock shape: one torch build per platform (pypi + each pytorch index), with the torch
+  // dependency inline-tables (`{ name = "filelock", ... }`) that must not be mistaken for the package name/source.
+  const uvLock = `version = 1
+revision = 1
+requires-python = ">=3.11"
+
+[[package]]
+name = "numpy"
+version = "2.1.3"
+source = { registry = "https://pypi.org/simple" }
+
+[[package]]
+name = "accelerate"
+version = "1.14.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "torch", version = "2.7.1+cu128", source = { registry = "https://download.pytorch.org/whl/cu128" } },
+    { name = "torch", version = "2.10.0+rocm7.1", source = { registry = "https://download.pytorch.org/whl/rocm7.1" } },
+]
+
+[[package]]
+name = "torch"
+version = "2.7.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "filelock" },
+    { name = "fsspec" },
+]
+
+[[package]]
+name = "torch"
+version = "2.7.1+cpu"
+source = { registry = "https://download.pytorch.org/whl/cpu" }
+
+[[package]]
+name = "torch"
+version = "2.7.1+cu128"
+source = { registry = "https://download.pytorch.org/whl/cu128" }
+
+[[package]]
+name = "torch"
+version = "2.10.0+rocm7.1"
+source = { registry = "https://download.pytorch.org/whl/rocm7.1" }
+
+[[package]]
+name = "torchvision"
+version = "0.22.1+cu128"
+source = { registry = "https://download.pytorch.org/whl/cu128" }
+
+[[package]]
+name = "torchvision"
+version = "0.25.0+rocm7.1"
+source = { registry = "https://download.pytorch.org/whl/rocm7.1" }
+
+[[package]]
+name = "triton-rocm"
+version = "3.6.0"
+source = { registry = "https://download.pytorch.org/whl/rocm7.1" }
+
+[[package]]
+name = "xformers"
+version = "0.0.31.post1"
+source = { registry = "https://pypi.org/simple" }
+`;
+
+  it('returns only the selected platform torch packages, with local version tags stripped', () => {
+    expect(getTorchPackagesFromLock(uvLock, 'cuda')).toEqual([
+      { name: 'torch', version: '2.7.1' },
+      { name: 'torchvision', version: '0.22.1' },
+    ]);
+  });
+
+  it('selects the rocm builds (different versions) for the rocm platform', () => {
+    expect(getTorchPackagesFromLock(uvLock, 'rocm')).toEqual([
+      { name: 'torch', version: '2.10.0' },
+      { name: 'torchvision', version: '0.25.0' },
+      { name: 'triton-rocm', version: '3.6.0' },
+    ]);
+  });
+
+  it('selects the cpu build for the cpu platform', () => {
+    expect(getTorchPackagesFromLock(uvLock, 'cpu')).toEqual([{ name: 'torch', version: '2.7.1' }]);
+  });
+
+  it('ignores packages resolved from pypi (e.g. the generic torch build, xformers)', () => {
+    const names = getTorchPackagesFromLock(uvLock, 'cuda').map((pkg) => pkg.name);
+    expect(names).not.toContain('numpy');
+    expect(names).not.toContain('xformers');
+    // The pypi torch build is 2.7.1 with no local tag; the cuda build we return is also base 2.7.1 - assert we only
+    // returned torch once (from the cu128 source), not twice.
+    expect(names.filter((n) => n === 'torch')).toHaveLength(1);
+  });
+
+  it('does not match torch sources nested inside another package’s dependencies list', () => {
+    // `accelerate` is a pypi package that lists torch (with a pytorch-index source) in its dependencies. It must not
+    // be reported as a torch-index package itself.
+    const names = getTorchPackagesFromLock(uvLock, 'cuda').map((pkg) => pkg.name);
+    expect(names).not.toContain('accelerate');
+  });
+
+  it('returns an empty array when the platform has no pytorch-index torch (e.g. macOS/pypi-only)', () => {
+    const lockWithoutTorch = `version = 1
+
+[[package]]
+name = "torch"
+version = "2.7.1"
+source = { registry = "https://pypi.org/simple" }
+`;
+    expect(getTorchPackagesFromLock(lockWithoutTorch, 'cuda')).toEqual([]);
   });
 });

--- a/src/shared/pins.test.ts
+++ b/src/shared/pins.test.ts
@@ -67,16 +67,27 @@ describe('pins', () => {
 });
 
 describe('getTorchPackagesFromLock', () => {
-  // Mirrors the real Invoke uv.lock shape: one torch build per platform (pypi + each pytorch index), with the torch
-  // dependency inline-tables (`{ name = "filelock", ... }`) that must not be mistaken for the package name/source.
+  // Mirrors the real Invoke uv.lock shape as closely as a fixture can: one torch build per platform (pypi + each
+  // pytorch index), the torch dependency inline-tables (`{ name = "filelock", ... }`) that must not be mistaken for the
+  // package name/source, plus the constructs a naive parser trips over - `resolution-markers`, `wheels`/`sdist` lists
+  // carrying pytorch-index URLs, `[package.optional-dependencies]` / `[package.metadata]` sub-sections, and
+  // same-name blocks split only by their resolution markers.
   const uvLock = `version = 1
-revision = 1
+revision = 3
 requires-python = ">=3.11"
+resolution-markers = [
+    "python_full_version >= '3.12' and sys_platform == 'linux'",
+    "python_full_version < '3.12' and sys_platform == 'win32'",
+]
 
 [[package]]
 name = "numpy"
 version = "2.1.3"
 source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/nu/numpy-2.1.3.tar.gz", hash = "sha256:aaaa" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/nu/numpy-2.1.3-cp312-win_amd64.whl", hash = "sha256:bbbb" },
+]
 
 [[package]]
 name = "accelerate"
@@ -85,6 +96,16 @@ source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "torch", version = "2.7.1+cu128", source = { registry = "https://download.pytorch.org/whl/cu128" } },
     { name = "torch", version = "2.10.0+rocm7.1", source = { registry = "https://download.pytorch.org/whl/rocm7.1" } },
+]
+
+[package.optional-dependencies]
+testing = [
+    { name = "torch", version = "2.7.1+cu128", source = { registry = "https://download.pytorch.org/whl/cu128" } },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "torch", specifier = ">=2.7.1" },
 ]
 
 [[package]]
@@ -100,16 +121,38 @@ dependencies = [
 name = "torch"
 version = "2.7.1+cpu"
 source = { registry = "https://download.pytorch.org/whl/cpu" }
+wheels = [
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.7.1%2Bcpu-cp312-cp312-win_amd64.whl", hash = "sha256:cccc" },
+]
 
 [[package]]
 name = "torch"
 version = "2.7.1+cu128"
 source = { registry = "https://download.pytorch.org/whl/cu128" }
+resolution-markers = [
+    "python_full_version >= '3.12' and sys_platform == 'linux'",
+]
+wheels = [
+    { url = "https://download-r2.pytorch.org/whl/cu128/torch-2.7.1%2Bcu128-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:dddd" },
+]
+
+[[package]]
+name = "torch"
+version = "2.7.1+cu128"
+source = { registry = "https://download.pytorch.org/whl/cu128" }
+resolution-markers = [
+    "python_full_version < '3.12' and sys_platform == 'win32'",
+]
 
 [[package]]
 name = "torch"
 version = "2.10.0+rocm7.1"
 source = { registry = "https://download.pytorch.org/whl/rocm7.1" }
+
+[[package]]
+name = "torchvision"
+version = "0.22.1+cpu"
+source = { registry = "https://download.pytorch.org/whl/cpu" }
 
 [[package]]
 name = "torchvision"
@@ -130,6 +173,17 @@ source = { registry = "https://download.pytorch.org/whl/rocm7.1" }
 name = "xformers"
 version = "0.0.31.post1"
 source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.12' and sys_platform == 'linux'",
+]
+
+[[package]]
+name = "xformers"
+version = "0.0.31.post1"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version < '3.12' and sys_platform == 'win32'",
+]
 `;
 
   it('returns only the selected platform torch packages, with local version tags stripped', () => {
@@ -147,8 +201,64 @@ source = { registry = "https://pypi.org/simple" }
     ]);
   });
 
-  it('selects the cpu build for the cpu platform', () => {
-    expect(getTorchPackagesFromLock(uvLock, 'cpu')).toEqual([{ name: 'torch', version: '2.7.1' }]);
+  it('selects the cpu builds for the cpu platform', () => {
+    expect(getTorchPackagesFromLock(uvLock, 'cpu')).toEqual([
+      { name: 'torch', version: '2.7.1' },
+      { name: 'torchvision', version: '0.22.1' },
+    ]);
+  });
+
+  it('returns each package once even when the lock splits it across resolution markers', () => {
+    // uv emits several same-name blocks with the same source when the resolution differs per marker. Emitting
+    // `torch==A torch==B` in one install command would be unsatisfiable.
+    const names = getTorchPackagesFromLock(uvLock, 'cuda').map((pkg) => pkg.name);
+    expect(names.filter((name) => name === 'torch')).toHaveLength(1);
+  });
+
+  it('ignores pytorch-index URLs that appear only in a wheels list', () => {
+    // The cpu block's `wheels` entry points at a cu128 URL in this fixture only via the r2 host; selection must key off
+    // the package's own top-level `source`, not any URL in the block.
+    const names = getTorchPackagesFromLock(uvLock, 'cuda').map((pkg) => pkg.name);
+    expect(names).toEqual(['torch', 'torchvision']);
+  });
+
+  it('matches the r2 host the pytorch registry is migrating to', () => {
+    const r2Lock = `version = 1
+
+[[package]]
+name = "torch"
+version = "2.7.1+cu128"
+source = { registry = "https://download-r2.pytorch.org/whl/cu128" }
+`;
+    expect(getTorchPackagesFromLock(r2Lock, 'cuda')).toEqual([{ name: 'torch', version: '2.7.1' }]);
+  });
+
+  it('matches the nightly and test channels', () => {
+    const nightlyLock = `version = 1
+
+[[package]]
+name = "torch"
+version = "2.9.0.dev20250101+cu128"
+source = { registry = "https://download.pytorch.org/whl/nightly/cu128" }
+
+[[package]]
+name = "torchvision"
+version = "0.24.0+cpu"
+source = { registry = "https://download.pytorch.org/whl/test/cpu" }
+`;
+    expect(getTorchPackagesFromLock(nightlyLock, 'cuda')).toEqual([{ name: 'torch', version: '2.9.0.dev20250101' }]);
+    expect(getTorchPackagesFromLock(nightlyLock, 'cpu')).toEqual([{ name: 'torchvision', version: '0.24.0' }]);
+  });
+
+  it('does not match a lookalike host', () => {
+    const lookalikeLock = `version = 1
+
+[[package]]
+name = "torch"
+version = "2.7.1+cu128"
+source = { registry = "https://notpytorch.org/whl/cu128" }
+`;
+    expect(getTorchPackagesFromLock(lookalikeLock, 'cuda')).toEqual([]);
   });
 
   it('ignores packages resolved from pypi (e.g. the generic torch build, xformers)', () => {

--- a/src/shared/pins.test.ts
+++ b/src/shared/pins.test.ts
@@ -165,9 +165,24 @@ version = "0.25.0+rocm7.1"
 source = { registry = "https://download.pytorch.org/whl/rocm7.1" }
 
 [[package]]
+name = "torch"
+version = "2.13.0+xpu"
+source = { registry = "https://download.pytorch.org/whl/xpu" }
+
+[[package]]
+name = "torchvision"
+version = "0.28.0+xpu"
+source = { registry = "https://download.pytorch.org/whl/xpu" }
+
+[[package]]
 name = "triton-rocm"
 version = "3.6.0"
 source = { registry = "https://download.pytorch.org/whl/rocm7.1" }
+
+[[package]]
+name = "triton-xpu"
+version = "3.7.2"
+source = { registry = "https://download.pytorch.org/whl/xpu" }
 
 [[package]]
 name = "xformers"
@@ -199,6 +214,20 @@ resolution-markers = [
       { name: 'torchvision', version: '0.25.0' },
       { name: 'triton-rocm', version: '3.6.0' },
     ]);
+  });
+
+  it('selects the intel xpu builds for the xpu platform', () => {
+    expect(getTorchPackagesFromLock(uvLock, 'xpu')).toEqual([
+      { name: 'torch', version: '2.13.0' },
+      { name: 'torchvision', version: '0.28.0' },
+      { name: 'triton-xpu', version: '3.7.2' },
+    ]);
+  });
+
+  it('does not confuse the xpu and cpu indexes', () => {
+    // `whl/xpu` and `whl/cpu` differ by one character; a sloppy pattern matches both.
+    expect(getTorchPackagesFromLock(uvLock, 'cpu').map((pkg) => pkg.version)).not.toContain('2.13.0');
+    expect(getTorchPackagesFromLock(uvLock, 'xpu').map((pkg) => pkg.version)).not.toContain('2.7.1');
   });
 
   it('selects the cpu builds for the cpu platform', () => {

--- a/src/shared/pins.ts
+++ b/src/shared/pins.ts
@@ -36,9 +36,9 @@ export type InvokeReleaseInstallFiles = {
   uvLock: string;
 };
 
-export type LockedPackage = { name: string; version: string };
+type LockedPackage = { name: string; version: string };
 
-export type TorchPlatform = 'cuda' | 'rocm' | 'cpu';
+type TorchPlatform = 'cuda' | 'rocm' | 'cpu';
 
 /**
  * Matches a package's own top-level `source` against the PyTorch download index for the given torch platform. Invoke's

--- a/src/shared/pins.ts
+++ b/src/shared/pins.ts
@@ -36,6 +36,62 @@ export type InvokeReleaseInstallFiles = {
   uvLock: string;
 };
 
+export type LockedPackage = { name: string; version: string };
+
+export type TorchPlatform = 'cuda' | 'rocm' | 'cpu';
+
+/**
+ * Matches a package's own top-level `source` against the PyTorch download index for the given torch platform. Invoke's
+ * lockfile contains a torch build for every platform (e.g. `.../whl/cu128`, `.../whl/rocm7.1`, `.../whl/cpu`); we only
+ * want the packages for the platform the user is actually installing. The exact suffix (cu128 vs cu126) is what the
+ * custom index overrides, so we match the platform category, not the exact URL.
+ *
+ * The pattern is anchored to the start of a line (`^` with the `m` flag) so it matches the package's own `source = {…}`
+ * line and NOT the `source = {…}` nested inside other packages' `dependencies = [ { name = "torch", …, source = {…} } ]`
+ * inline tables (which are indented) - otherwise every package that depends on torch would match.
+ */
+const TORCH_INDEX_SOURCE_PATTERN: Record<TorchPlatform, RegExp> = {
+  cuda: /^source\s*=\s*\{[^}]*download\.pytorch\.org\/whl\/cu\d+[^}]*\}/m,
+  rocm: /^source\s*=\s*\{[^}]*download\.pytorch\.org\/whl\/rocm[^}]*\}/m,
+  cpu: /^source\s*=\s*\{[^}]*download\.pytorch\.org\/whl\/cpu[^}]*\}/m,
+};
+
+/**
+ * Parse the torch-family packages for a given torch platform out of an Invoke release's `uv.lock`.
+ *
+ * We select every `[[package]]` block whose `source` points at the PyTorch download index for `torchPlatform` (e.g.
+ * for `cuda`, `https://download.pytorch.org/whl/cu128`). These are exactly the packages a custom torch index would
+ * replace - and we deliberately ignore the other platforms' torch builds, which carry different versions and would
+ * otherwise conflict.
+ *
+ * The local version tag (e.g. `+cu128`) is stripped so the returned `==<version>` pin matches the equivalent build on
+ * a different index (e.g. `2.7.1` matches `2.7.1+cu126`). Regex-based on purpose to avoid pulling in a TOML parser
+ * dependency, mirroring `getDeclaredOptionalDependencies` in the install manager.
+ */
+export const getTorchPackagesFromLock = (uvLock: string, torchPlatform: TorchPlatform): LockedPackage[] => {
+  const sourcePattern = TORCH_INDEX_SOURCE_PATTERN[torchPlatform];
+  const packages: LockedPackage[] = [];
+
+  // Split into individual `[[package]]` blocks. The first chunk (before the first `[[package]]`) is dropped.
+  for (const block of uvLock.split(/\n\[\[package\]\]/).slice(1)) {
+    // Only consider packages resolved from the PyTorch download index for the selected platform.
+    if (!sourcePattern.test(block)) {
+      continue;
+    }
+
+    const name = block.match(/^name\s*=\s*"([^"]+)"/m)?.[1];
+    const version = block.match(/^version\s*=\s*"([^"]+)"/m)?.[1];
+    if (!name || !version) {
+      continue;
+    }
+
+    // Strip the local version tag (e.g. `2.7.1+cu128` -> `2.7.1`) so the pin resolves against a different index.
+    packages.push({ name, version: version.split('+')[0]! });
+  }
+
+  return packages;
+};
+
 const getInvokeReleaseTag = (targetVersion: string): string => {
   return targetVersion.startsWith('v') ? targetVersion : `v${targetVersion}`;
 };

--- a/src/shared/pins.ts
+++ b/src/shared/pins.ts
@@ -5,6 +5,9 @@ const zPlatformIndicies = z.object({
   cuda: z.string().optional(),
   cpu: z.string().optional(),
   rocm: z.string().optional(),
+  // Intel XPU. Present for win32/linux from the Invoke release that added the `xpu` extra; absent on darwin and on
+  // older releases, hence optional like every other entry.
+  xpu: z.string().optional(),
 });
 
 const zPins = z.object({
@@ -38,7 +41,7 @@ export type InvokeReleaseInstallFiles = {
 
 export type LockedPackage = { name: string; version: string };
 
-type TorchPlatform = 'cuda' | 'rocm' | 'cpu';
+type TorchPlatform = 'cuda' | 'rocm' | 'xpu' | 'cpu';
 
 /**
  * Matches a package's own top-level `source` against the PyTorch download index for the given torch platform. Invoke's
@@ -59,6 +62,7 @@ type TorchPlatform = 'cuda' | 'rocm' | 'cpu';
 const TORCH_INDEX_SOURCE_PATTERN: Record<TorchPlatform, RegExp> = {
   cuda: /^source\s*=\s*\{[^}]*\bpytorch\.org\/whl\/(?:[\w.+-]+\/)?cu\d+[^}]*\}/m,
   rocm: /^source\s*=\s*\{[^}]*\bpytorch\.org\/whl\/(?:[\w.+-]+\/)?rocm[^}]*\}/m,
+  xpu: /^source\s*=\s*\{[^}]*\bpytorch\.org\/whl\/(?:[\w.+-]+\/)?xpu\b[^}]*\}/m,
   cpu: /^source\s*=\s*\{[^}]*\bpytorch\.org\/whl\/(?:[\w.+-]+\/)?cpu\b[^}]*\}/m,
 };
 

--- a/src/shared/pins.ts
+++ b/src/shared/pins.ts
@@ -36,7 +36,7 @@ export type InvokeReleaseInstallFiles = {
   uvLock: string;
 };
 
-type LockedPackage = { name: string; version: string };
+export type LockedPackage = { name: string; version: string };
 
 type TorchPlatform = 'cuda' | 'rocm' | 'cpu';
 
@@ -46,14 +46,20 @@ type TorchPlatform = 'cuda' | 'rocm' | 'cpu';
  * want the packages for the platform the user is actually installing. The exact suffix (cu128 vs cu126) is what the
  * custom index overrides, so we match the platform category, not the exact URL.
  *
+ * The host is matched as `<anything>.pytorch.org` rather than the literal `download.pytorch.org`: PyTorch is in the
+ * middle of migrating to `download-r2.pytorch.org` (today's lock already serves every *wheel* from there), and the
+ * channel segment is optional so the nightly/test channels (`.../whl/nightly/cu128`) match too. A miss here silently
+ * turns the whole override into a no-op, so the pattern is deliberately permissive about everything except the
+ * platform category.
+ *
  * The pattern is anchored to the start of a line (`^` with the `m` flag) so it matches the package's own `source = {…}`
  * line and NOT the `source = {…}` nested inside other packages' `dependencies = [ { name = "torch", …, source = {…} } ]`
  * inline tables (which are indented) - otherwise every package that depends on torch would match.
  */
 const TORCH_INDEX_SOURCE_PATTERN: Record<TorchPlatform, RegExp> = {
-  cuda: /^source\s*=\s*\{[^}]*download\.pytorch\.org\/whl\/cu\d+[^}]*\}/m,
-  rocm: /^source\s*=\s*\{[^}]*download\.pytorch\.org\/whl\/rocm[^}]*\}/m,
-  cpu: /^source\s*=\s*\{[^}]*download\.pytorch\.org\/whl\/cpu[^}]*\}/m,
+  cuda: /^source\s*=\s*\{[^}]*\bpytorch\.org\/whl\/(?:[\w.+-]+\/)?cu\d+[^}]*\}/m,
+  rocm: /^source\s*=\s*\{[^}]*\bpytorch\.org\/whl\/(?:[\w.+-]+\/)?rocm[^}]*\}/m,
+  cpu: /^source\s*=\s*\{[^}]*\bpytorch\.org\/whl\/(?:[\w.+-]+\/)?cpu\b[^}]*\}/m,
 };
 
 /**
@@ -67,10 +73,16 @@ const TORCH_INDEX_SOURCE_PATTERN: Record<TorchPlatform, RegExp> = {
  * The local version tag (e.g. `+cu128`) is stripped so the returned `==<version>` pin matches the equivalent build on
  * a different index (e.g. `2.7.1` matches `2.7.1+cu126`). Regex-based on purpose to avoid pulling in a TOML parser
  * dependency, mirroring `getDeclaredOptionalDependencies` in the install manager.
+ *
+ * Results are deduplicated by package name, keeping the first match. uv splits a package into several `[[package]]`
+ * blocks with the same name and source when the resolution differs per `resolution-markers` - today's lock does this
+ * for `xformers` and the `nvidia-*-cu12` family, and nothing exempts the torch family from it. Emitting
+ * `torch==A torch==B` in one command would be an unsatisfiable requirement set.
  */
 export const getTorchPackagesFromLock = (uvLock: string, torchPlatform: TorchPlatform): LockedPackage[] => {
   const sourcePattern = TORCH_INDEX_SOURCE_PATTERN[torchPlatform];
   const packages: LockedPackage[] = [];
+  const seenNames = new Set<string>();
 
   // Split into individual `[[package]]` blocks. The first chunk (before the first `[[package]]`) is dropped.
   for (const block of uvLock.split(/\n\[\[package\]\]/).slice(1)) {
@@ -81,9 +93,10 @@ export const getTorchPackagesFromLock = (uvLock: string, torchPlatform: TorchPla
 
     const name = block.match(/^name\s*=\s*"([^"]+)"/m)?.[1];
     const version = block.match(/^version\s*=\s*"([^"]+)"/m)?.[1];
-    if (!name || !version) {
+    if (!name || !version || seenNames.has(name)) {
       continue;
     }
+    seenNames.add(name);
 
     // Strip the local version tag (e.g. `2.7.1+cu128` -> `2.7.1`) so the pin resolves against a different index.
     packages.push({ name, version: version.split('+')[0]! });

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -122,13 +122,22 @@ export const GPU_TYPE_MAP: Record<GpuType, string> = {
 export type GpuBackend = 'cuda' | 'rocm' | 'metal' | 'cpu';
 
 /**
+ * The hardware vendor behind the detected backend. `cpu` means no dedicated GPU vendor was identified. Note that a
+ * vendor can be identified even when the usable backend is `cpu` - e.g. a discrete AMD GPU on Windows, where ROCm is
+ * not supported.
+ */
+export type GpuVendor = 'nvidia' | 'amd' | 'apple' | 'cpu';
+
+export type GpuConfidence = 'high' | 'medium' | 'low' | 'weak-signal' | 'none';
+
+/**
  * Result of the best-effort hardware probe for the compute backend. Note that `cuda` does not distinguish the Nvidia
  * generation (20xx vs 30xx+) - that still requires a user choice because it cannot be reliably auto-detected.
  */
 export type GpuDetectionResult = {
   backend: GpuBackend;
-  vendor: string;
-  confidence: 'high' | 'medium' | 'low' | 'weak-signal' | 'none';
+  vendor: GpuVendor;
+  confidence: GpuConfidence;
   /** Human-readable explanation of why this backend was chosen (for logging/debugging). */
   decision: string;
 };

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -117,6 +117,23 @@ export const GPU_TYPE_MAP: Record<GpuType, string> = {
 };
 
 /**
+ * The compute backend detected on the system. Advisory only - the user confirms or overrides it in the install flow.
+ */
+export type GpuBackend = 'cuda' | 'rocm' | 'metal' | 'cpu';
+
+/**
+ * Result of the best-effort hardware probe for the compute backend. Note that `cuda` does not distinguish the Nvidia
+ * generation (20xx vs 30xx+) - that still requires a user choice because it cannot be reliably auto-detected.
+ */
+export type GpuDetectionResult = {
+  backend: GpuBackend;
+  vendor: string;
+  confidence: 'high' | 'medium' | 'low' | 'weak-signal' | 'none';
+  /** Human-readable explanation of why this backend was chosen (for logging/debugging). */
+  decision: string;
+};
+
+/**
  * Supported operating systems.
  */
 export type OperatingSystem = 'Windows' | 'macOS' | 'Linux';
@@ -305,7 +322,13 @@ type InstallProcessIpcEvents = Namespaced<
   'install-process',
   {
     'get-status': () => WithTimestamp<InstallProcessStatus>;
-    'start-install': (location: string, gpuType: GpuType, version: string, repair?: boolean) => void;
+    'start-install': (
+      location: string,
+      gpuType: GpuType,
+      version: string,
+      customTorchIndexUrl?: string,
+      repair?: boolean
+    ) => void;
     'cancel-install': () => void;
     resize: (cols: number, rows: number) => void;
   }
@@ -341,6 +364,7 @@ type UtilIpcEvents = Namespaced<
     'get-default-install-dir': () => string;
     'open-directory': (path: string) => string;
     'get-launcher-version': () => string;
+    'detect-gpu': () => GpuDetectionResult;
   }
 >;
 

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -116,7 +116,7 @@ export const schema: Schema<StoreData> = {
  * - Whether to install xformers - torch's own SDP is faster for 30xx + series GPUs, otherwise xformers is faster.
  * - Which pypi indices to use for torch.
  */
-export type GpuType = 'nvidia<30xx' | 'nvidia>=30xx' | 'amd' | 'nogpu';
+export type GpuType = 'nvidia<30xx' | 'nvidia>=30xx' | 'amd' | 'intel' | 'nogpu';
 
 /**
  * A map of GPU types to human-readable names.
@@ -125,20 +125,21 @@ export const GPU_TYPE_MAP: Record<GpuType, string> = {
   'nvidia<30xx': 'Nvidia (20xx and below)',
   'nvidia>=30xx': 'Nvidia (30xx and above)',
   amd: 'AMD',
+  intel: 'Intel Arc',
   nogpu: 'No dedicated GPU',
 };
 
 /**
  * The compute backend detected on the system. Advisory only - the user confirms or overrides it in the install flow.
  */
-export type GpuBackend = 'cuda' | 'rocm' | 'metal' | 'cpu';
+export type GpuBackend = 'cuda' | 'rocm' | 'xpu' | 'metal' | 'cpu';
 
 /**
  * The hardware vendor behind the detected backend. `cpu` means no dedicated GPU vendor was identified. Note that a
  * vendor can be identified even when the usable backend is `cpu` - e.g. a discrete AMD GPU on Windows, where ROCm is
- * not supported.
+ * not supported, or Intel graphics too old for PyTorch's XPU build.
  */
-type GpuVendor = 'nvidia' | 'amd' | 'apple' | 'cpu';
+type GpuVendor = 'nvidia' | 'amd' | 'intel' | 'apple' | 'cpu';
 
 /**
  * How much the detection result should be trusted. `weak-signal` means hardware was seen but the usable backend could

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -126,9 +126,14 @@ export type GpuBackend = 'cuda' | 'rocm' | 'metal' | 'cpu';
  * vendor can be identified even when the usable backend is `cpu` - e.g. a discrete AMD GPU on Windows, where ROCm is
  * not supported.
  */
-export type GpuVendor = 'nvidia' | 'amd' | 'apple' | 'cpu';
+type GpuVendor = 'nvidia' | 'amd' | 'apple' | 'cpu';
 
-export type GpuConfidence = 'high' | 'medium' | 'low' | 'weak-signal' | 'none';
+/**
+ * How much the detection result should be trusted. `weak-signal` means hardware was seen but the usable backend could
+ * not be confirmed (e.g. integrated Radeon graphics with no ROCm build) - the backend falls back to `cpu`, but the UI
+ * can still explain what was found instead of claiming there is no GPU.
+ */
+export type GpuConfidence = 'high' | 'medium' | 'weak-signal' | 'none';
 
 /**
  * Result of the best-effort hardware probe for the compute backend. Note that `cuda` does not distinguish the Nvidia

--- a/src/shared/url.test.ts
+++ b/src/shared/url.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  hasInsecureCredentials,
+  isCustomTorchIndexUrlInvalid,
+  redactUrlCredentials,
+  splitIndexUrlCredentials,
+} from './url';
+
+describe('isCustomTorchIndexUrlInvalid', () => {
+  it('accepts an empty value (the field is optional)', () => {
+    expect(isCustomTorchIndexUrlInvalid('')).toBe(false);
+    expect(isCustomTorchIndexUrlInvalid('   ')).toBe(false);
+  });
+
+  it('accepts http(s) URLs', () => {
+    expect(isCustomTorchIndexUrlInvalid('https://download.pytorch.org/whl/cu126')).toBe(false);
+    expect(isCustomTorchIndexUrlInvalid('http://nexus.corp:8081/repository/pypi/simple')).toBe(false);
+  });
+
+  it('rejects anything that is not an http(s) URL', () => {
+    expect(isCustomTorchIndexUrlInvalid('cu126')).toBe(true);
+    expect(isCustomTorchIndexUrlInvalid('htps://download.pytorch.org/whl/cu126')).toBe(true);
+    expect(isCustomTorchIndexUrlInvalid('file:///srv/wheels')).toBe(true);
+  });
+});
+
+describe('redactUrlCredentials', () => {
+  it('redacts credentials in a well-formed URL', () => {
+    expect(redactUrlCredentials('https://myuser:ghp_TOKEN@nexus.corp/simple')).toBe(
+      'https://***:***@nexus.corp/simple'
+    );
+  });
+
+  it('redacts a username-only userinfo', () => {
+    expect(redactUrlCredentials('https://myuser@nexus.corp/simple')).toBe('https://***@nexus.corp/simple');
+  });
+
+  it('redacts credentials in a scheme-less value', () => {
+    // The WHATWG URL parser reads `myuser:` as the scheme here, so `url.username` is empty and a parser-based
+    // implementation returns this untouched - straight into the invalid-URL error path, which logs the value.
+    expect(redactUrlCredentials('myuser:ghp_TOKEN@nexus.corp/simple')).toBe('***:***@nexus.corp/simple');
+  });
+
+  it('redacts credentials in a value the URL parser rejects', () => {
+    expect(redactUrlCredentials('https://myuser:ghp_TOKEN@nexus.corp:999999/simple')).toBe(
+      'https://***:***@nexus.corp:999999/simple'
+    );
+  });
+
+  it('redacts up to the last @ so an unencoded @ in the password does not leak', () => {
+    expect(redactUrlCredentials('https://myuser:p@ssw0rd@nexus.corp/simple')).toBe('https://***:***@nexus.corp/simple');
+  });
+
+  it('leaves a URL without credentials unchanged', () => {
+    expect(redactUrlCredentials('https://download.pytorch.org/whl/cu126')).toBe(
+      'https://download.pytorch.org/whl/cu126'
+    );
+    expect(redactUrlCredentials('https://download.pytorch.org/whl/cu126/torch@2.7.1')).toBe(
+      'https://download.pytorch.org/whl/cu126/torch@2.7.1'
+    );
+  });
+});
+
+describe('splitIndexUrlCredentials', () => {
+  it('splits credentials out of the URL so they can go in the environment', () => {
+    expect(splitIndexUrlCredentials('https://myuser:ghp_TOKEN@nexus.corp/simple')).toEqual({
+      url: 'https://nexus.corp/simple',
+      username: 'myuser',
+      password: 'ghp_TOKEN',
+    });
+  });
+
+  it('decodes percent-encoded userinfo', () => {
+    expect(splitIndexUrlCredentials('https://my%40user:p%40ss@nexus.corp/simple')).toEqual({
+      url: 'https://nexus.corp/simple',
+      username: 'my@user',
+      password: 'p@ss',
+    });
+  });
+
+  it('returns the URL untouched when there are no credentials', () => {
+    expect(splitIndexUrlCredentials('https://download.pytorch.org/whl/cu126')).toEqual({
+      url: 'https://download.pytorch.org/whl/cu126',
+    });
+  });
+});
+
+describe('hasInsecureCredentials', () => {
+  it('flags credentials sent over plain http', () => {
+    expect(hasInsecureCredentials('http://myuser:ghp_TOKEN@nexus.corp/simple')).toBe(true);
+  });
+
+  it('does not flag https credentials or credential-free http', () => {
+    expect(hasInsecureCredentials('https://myuser:ghp_TOKEN@nexus.corp/simple')).toBe(false);
+    expect(hasInsecureCredentials('http://nexus.corp/simple')).toBe(false);
+  });
+});

--- a/src/shared/url.ts
+++ b/src/shared/url.ts
@@ -1,0 +1,48 @@
+/**
+ * Shared URL helpers used by both the renderer (input validation) and the main process (defense-in-depth
+ * re-validation and log redaction). Kept here so both sides apply exactly the same rules.
+ */
+
+/**
+ * Whether a string parses as an http(s) URL.
+ */
+export const isHttpUrl = (value: string): boolean => {
+  try {
+    const url = new URL(value);
+    return url.protocol === 'http:' || url.protocol === 'https:';
+  } catch {
+    return false;
+  }
+};
+
+/**
+ * A custom torch index URL is optional. When set, it must be a valid http(s) URL. Anything else (typos like
+ * `htps://...`, a bare `cu126`, etc.) is rejected so it doesn't surface minutes into an install as a cryptic uv
+ * resolver error.
+ */
+export const isCustomTorchIndexUrlInvalid = (value: string): boolean => {
+  const trimmed = value.trim();
+  return trimmed.length > 0 && !isHttpUrl(trimmed);
+};
+
+/**
+ * Redact any embedded credentials (`https://user:pass@host/...`) from a URL before it is written to the install log.
+ * Returns the input unchanged if it doesn't parse or carries no credentials.
+ */
+export const redactUrlCredentials = (value: string): string => {
+  try {
+    const url = new URL(value);
+    if (!url.username && !url.password) {
+      return value;
+    }
+    if (url.username) {
+      url.username = '***';
+    }
+    if (url.password) {
+      url.password = '***';
+    }
+    return url.toString();
+  } catch {
+    return value;
+  }
+};

--- a/src/shared/url.ts
+++ b/src/shared/url.ts
@@ -6,7 +6,7 @@
 /**
  * Whether a string parses as an http(s) URL.
  */
-export const isHttpUrl = (value: string): boolean => {
+const isHttpUrl = (value: string): boolean => {
   try {
     const url = new URL(value);
     return url.protocol === 'http:' || url.protocol === 'https:';

--- a/src/shared/url.ts
+++ b/src/shared/url.ts
@@ -1,6 +1,6 @@
 /**
- * Shared URL helpers used by both the renderer (input validation) and the main process (defense-in-depth
- * re-validation and log redaction). Kept here so both sides apply exactly the same rules.
+ * Shared URL helpers used by both the renderer (input validation, review display) and the main process (defense-in-depth
+ * re-validation, credential handling and log redaction). Kept here so both sides apply exactly the same rules.
  */
 
 /**
@@ -26,23 +26,72 @@ export const isCustomTorchIndexUrlInvalid = (value: string): boolean => {
 };
 
 /**
- * Redact any embedded credentials (`https://user:pass@host/...`) from a URL before it is written to the install log.
- * Returns the input unchanged if it doesn't parse or carries no credentials.
+ * Matches the `user:pass@` userinfo section of a URL-ish string, with or without a scheme.
+ *
+ * We deliberately do not use the WHATWG `URL` parser for redaction. A scheme-less value like `user:token@host/simple`
+ * parses `user:` as the *scheme*, so `url.username`/`url.password` come back empty and the credentials would survive
+ * untouched - and that is exactly the shape that reaches the invalid-URL error path, which logs the value. The same
+ * goes for anything else `new URL()` throws on (e.g. an out-of-range port).
+ *
+ * The userinfo group is greedy so it backtracks to the *last* `@` before the first path separator, which keeps
+ * passwords containing an unencoded `@` from leaking.
+ */
+const USERINFO_PATTERN = /^((?:[a-zA-Z][a-zA-Z0-9+.-]*:)?\/\/)?([^/?#\s]+)@/;
+
+/**
+ * Redact any embedded credentials (`https://user:pass@host/...`) from a URL before it is written to the install log or
+ * rendered in the UI. Returns the input unchanged if it carries no credentials.
  */
 export const redactUrlCredentials = (value: string): string => {
+  return value.replace(USERINFO_PATTERN, (_match, scheme: string | undefined, userinfo: string) => {
+    const redacted = userinfo.includes(':') ? '***:***' : '***';
+    return `${scheme ?? ''}${redacted}@`;
+  });
+};
+
+type IndexUrlCredentials = {
+  /** The URL with any userinfo removed, safe to pass as a command-line argument. */
+  url: string;
+  username?: string;
+  password?: string;
+};
+
+/**
+ * Split any embedded credentials out of an index URL.
+ *
+ * Command-line arguments are world-readable while the process runs (`ps auxww`, `/proc/<pid>/cmdline`, Task Manager),
+ * and a torch download is a multi-GB, multi-minute process. uv can take index credentials from the environment
+ * instead (`UV_INDEX_<NAME>_USERNAME` / `_PASSWORD`), so we strip them from the URL and pass them that way.
+ *
+ * Only meaningful for values that have already passed {@link isCustomTorchIndexUrlInvalid}; anything the URL parser
+ * rejects is returned unchanged.
+ */
+export const splitIndexUrlCredentials = (value: string): IndexUrlCredentials => {
   try {
     const url = new URL(value);
     if (!url.username && !url.password) {
-      return value;
+      return { url: value };
     }
-    if (url.username) {
-      url.username = '***';
-    }
-    if (url.password) {
-      url.password = '***';
-    }
-    return url.toString();
+    // Userinfo is percent-encoded in the URL; uv expects the decoded values in the environment.
+    const username = url.username ? decodeURIComponent(url.username) : undefined;
+    const password = url.password ? decodeURIComponent(url.password) : undefined;
+    url.username = '';
+    url.password = '';
+    return { url: url.toString(), username, password };
   } catch {
-    return value;
+    return { url: value };
+  }
+};
+
+/**
+ * Whether a URL sends credentials in cleartext over the wire (`http://user:pass@...`). Worth a warning - the user may
+ * not realise their token is not protected by TLS.
+ */
+export const hasInsecureCredentials = (value: string): boolean => {
+  try {
+    const url = new URL(value);
+    return url.protocol === 'http:' && Boolean(url.username || url.password);
+  } catch {
+    return false;
   }
 };


### PR DESCRIPTION
## Custom Torch index Override

Re-implements the custom PyTorch index feature (previously #133) on top of the bootstrap install architecture (#135), and adds hardware auto-detection with a confirmation step in the install flow.

Custom torch index:
- Add a per-install "Custom PyTorch index" field to the Configure step (validated http(s) URL), threaded through the start-install IPC. Replaces the previous global setting, which sidesteps the stale-override problem.
- Legacy installs (<6.14): the custom URL replaces the pinned torch index.
- Bootstrap installs (>=6.14): the torch-family packages are skipped during `uv sync` (`--no-install-package`) and installed once from the custom index afterwards, so torch is not downloaded twice. Package names and versions are parsed from the release uv.lock (getTorchPackagesFromLock), scoped to the selected torch platform, with local version tags stripped so `==<version>` matches the equivalent build on a different index.
- Surface the active override in the Review step.

## GPU auto-detection from [here](https://discord.com/channels/1020123559063990373/1083864753543331981/1523008428287725758)
- Port the hardware probe to src/main/gpu-detection.ts (async execFile so it never blocks the main process), exposed via a new util:detect-gpu IPC.
- The Configure step auto-detects on entry and asks the user to confirm; on "no" or detection failure the manual picker is shown, and auto-detect stays reachable from there. CUDA always prompts for the Nvidia generation, which cannot be auto-detected. The confirmation sub-view is kept in the store so it survives navigating away from and back to the step.

## Tested on
- [ ] Linux CPU
- [x] Linux RCOM
- [ ] Linux CUDA
- [x] Linux INTEL
- [ ] Windows CPU
- [x] Windows RCOM
- [x] Windows CUDA
- [ ] Windows INTEL
- [ ] Apple

