### PR TITLE
Feature: restart UI window

### DIFF
--- a/src/main/invoke-manager.ts
+++ b/src/main/invoke-manager.ts
@@ -37,6 +37,7 @@ export class InvokeManager {
   private commandRunner: CommandRunner;
   private cols: number | undefined;
   private rows: number | undefined;
+  private isClosingWindowWithoutExiting: boolean;
 
   constructor(arg: {
     store: Store<StoreData>;
@@ -60,6 +61,7 @@ export class InvokeManager {
     this.commandRunner = new CommandRunner();
     this.cols = undefined;
     this.rows = undefined;
+    this.isClosingWindowWithoutExiting = false;
   }
 
   getStatus = (): WithTimestamp<InvokeProcessStatus> => {
@@ -259,6 +261,9 @@ export class InvokeManager {
     });
 
     window.on('close', () => {
+      if (this.isClosingWindowWithoutExiting) {
+        return;
+      }
       this.exitInvoke();
     });
 
@@ -274,6 +279,10 @@ export class InvokeManager {
             : details.reason === 'killed'
               ? 'Killed'
               : `Unknown (${details.reason})`;
+
+      if (this.isClosingWindowWithoutExiting) {
+        return;
+      }
 
       this.log.error(c.red(`UI Window unexpectedly exited with exit code ${details.exitCode}: ${reasonMessage}\r\n`));
 
@@ -358,6 +367,27 @@ export class InvokeManager {
     this.updateStatus({ type: 'running', data: this.lastRunningData });
   };
 
+  restartWindow = async (): Promise<void> => {
+    if (!this.lastRunningData) {
+      this.log.error(c.red('Cannot restart window - no running data available\r\n'));
+      return;
+    }
+
+    if (!this.commandRunner.isRunning()) {
+      this.log.error(c.red('Cannot restart window - process is not running\r\n'));
+      return;
+    }
+
+    this.log.info('Restarting Invoke UI window...\r\n');
+
+    if (this.window && !this.window.isDestroyed()) {
+      await this.closeWindowWithoutExiting();
+    }
+
+    this.createWindow(this.lastRunningData.loopbackUrl);
+    this.updateStatus({ type: 'running', data: this.lastRunningData });
+  };
+
   /**
    * Exit Invoke and wait for process to properly terminate
    */
@@ -376,6 +406,32 @@ export class InvokeManager {
       this.window.destroy();
     }
     this.window = null;
+  };
+
+  closeWindowWithoutExiting = async (): Promise<void> => {
+    if (!this.window) {
+      return;
+    }
+
+    const window = this.window;
+    this.isClosingWindowWithoutExiting = true;
+
+    try {
+      await new Promise<void>((resolve) => {
+        window.once('closed', resolve);
+        if (window.isDestroyed()) {
+          resolve();
+          return;
+        }
+        window.destroy();
+      });
+
+      if (this.window === window) {
+        this.window = null;
+      }
+    } finally {
+      this.isClosingWindowWithoutExiting = false;
+    }
   };
 
   /**
@@ -424,6 +480,9 @@ export const createInvokeManager = (arg: {
   ipc.handle('invoke-process:reopen-window', () => {
     invokeManager.reopenWindow();
   });
+  ipc.handle('invoke-process:restart-window', async () => {
+    await invokeManager.restartWindow();
+  });
   ipc.handle('invoke-process:resize', (_, cols, rows) => {
     invokeManager.resizePty(cols, rows);
   });
@@ -435,6 +494,8 @@ export const createInvokeManager = (arg: {
     }
     ipcMain.removeHandler('invoke-process:start-invoke');
     ipcMain.removeHandler('invoke-process:exit-invoke');
+    ipcMain.removeHandler('invoke-process:reopen-window');
+    ipcMain.removeHandler('invoke-process:restart-window');
     ipcMain.removeHandler('invoke-process:resize');
   };
 

--- a/src/main/invoke-manager.ts
+++ b/src/main/invoke-manager.ts
@@ -37,7 +37,8 @@ export class InvokeManager {
   private commandRunner: CommandRunner;
   private cols: number | undefined;
   private rows: number | undefined;
-  private isClosingWindowWithoutExiting: boolean;
+  private windowsClosingWithoutExiting: WeakSet<BrowserWindow>;
+  private isRestartingWindow: boolean;
 
   constructor(arg: {
     store: Store<StoreData>;
@@ -61,7 +62,8 @@ export class InvokeManager {
     this.commandRunner = new CommandRunner();
     this.cols = undefined;
     this.rows = undefined;
-    this.isClosingWindowWithoutExiting = false;
+    this.windowsClosingWithoutExiting = new WeakSet();
+    this.isRestartingWindow = false;
   }
 
   getStatus = (): WithTimestamp<InvokeProcessStatus> => {
@@ -83,6 +85,7 @@ export class InvokeManager {
   };
 
   startInvoke = async (location: string) => {
+    this.lastRunningData = null;
     this.updateStatus({ type: 'starting' });
 
     // Clear logs from previous session
@@ -149,7 +152,7 @@ export class InvokeManager {
         this.lastRunningData = data;
 
         // Only open the window if server mode is not enabled
-        if (!this.store.get('serverMode')) {
+        if (!this.store.get('serverMode') && (!this.window || this.window.isDestroyed())) {
           this.createWindow(data.loopbackUrl);
         }
 
@@ -209,6 +212,7 @@ export class InvokeManager {
               this.log.info(c.red('Invoke process was killed unexpectedly\r\n'));
             }
 
+            this.lastRunningData = null;
             this.closeWindow();
           },
         }
@@ -261,9 +265,6 @@ export class InvokeManager {
     });
 
     window.on('close', () => {
-      if (this.isClosingWindowWithoutExiting) {
-        return;
-      }
       this.exitInvoke();
     });
 
@@ -280,7 +281,7 @@ export class InvokeManager {
               ? 'Killed'
               : `Unknown (${details.reason})`;
 
-      if (this.isClosingWindowWithoutExiting) {
+      if (this.windowsClosingWithoutExiting.has(window)) {
         return;
       }
 
@@ -299,12 +300,14 @@ export class InvokeManager {
       }
 
       // Close the crashed window (it may still be visible but unresponsive)
-      if (this.window && !this.window.isDestroyed()) {
-        this.window.destroy();
+      if (!window.isDestroyed()) {
+        window.destroy();
       }
 
       // Clean up the window reference
-      this.window = null;
+      if (this.window === window) {
+        this.window = null;
+      }
     });
 
     window.webContents.on('unresponsive', () => {
@@ -368,6 +371,16 @@ export class InvokeManager {
   };
 
   restartWindow = async (): Promise<void> => {
+    if (this.isRestartingWindow) {
+      this.log.warn('Window restart is already in progress\r\n');
+      return;
+    }
+
+    if (!this.window || this.window.isDestroyed()) {
+      this.log.warn('Cannot restart window - window is not open\r\n');
+      return;
+    }
+
     if (!this.lastRunningData) {
       this.log.error(c.red('Cannot restart window - no running data available\r\n'));
       return;
@@ -379,13 +392,19 @@ export class InvokeManager {
     }
 
     this.log.info('Restarting Invoke UI window...\r\n');
+    this.isRestartingWindow = true;
 
-    if (this.window && !this.window.isDestroyed()) {
-      await this.closeWindowWithoutExiting();
+    try {
+      const closed = await this.closeWindowWithoutExiting();
+      if (!closed) {
+        return;
+      }
+
+      this.createWindow(this.lastRunningData.loopbackUrl);
+      this.updateStatus({ type: 'running', data: this.lastRunningData });
+    } finally {
+      this.isRestartingWindow = false;
     }
-
-    this.createWindow(this.lastRunningData.loopbackUrl);
-    this.updateStatus({ type: 'running', data: this.lastRunningData });
   };
 
   /**
@@ -395,6 +414,7 @@ export class InvokeManager {
     this.log.info(c.cyan('Shutting down...\r\n'));
     this.updateStatus({ type: 'exiting' });
     await this.killProcess();
+    this.lastRunningData = null;
     this.closeWindow();
   };
 
@@ -408,30 +428,67 @@ export class InvokeManager {
     this.window = null;
   };
 
-  closeWindowWithoutExiting = async (): Promise<void> => {
+  saveAppWindowProps = (window: BrowserWindow): void => {
+    this.store.set('appWindowProps', {
+      bounds: window.getBounds(),
+      isMaximized: window.isMaximized(),
+      isFullScreen: window.isFullScreen(),
+    });
+  };
+
+  closeWindowWithoutExiting = async (): Promise<boolean> => {
     if (!this.window) {
-      return;
+      return true;
     }
 
     const window = this.window;
-    this.isClosingWindowWithoutExiting = true;
-
-    try {
-      await new Promise<void>((resolve) => {
-        window.once('closed', resolve);
-        if (window.isDestroyed()) {
-          resolve();
-          return;
-        }
-        window.destroy();
-      });
-
+    if (window.isDestroyed()) {
       if (this.window === window) {
         this.window = null;
       }
-    } finally {
-      this.isClosingWindowWithoutExiting = false;
+      return true;
     }
+
+    this.saveAppWindowProps(window);
+    this.windowsClosingWithoutExiting.add(window);
+
+    const closed = await new Promise<boolean>((resolve) => {
+      const timeout = setTimeout(() => {
+        window.off('closed', handleClosed);
+        this.log.error(c.red('Timed out while restarting Invoke UI window\r\n'));
+        resolve(false);
+      }, 5000);
+
+      const handleClosed = () => {
+        clearTimeout(timeout);
+        resolve(true);
+      };
+
+      window.once('closed', handleClosed);
+
+      try {
+        window.destroy();
+      } catch (error) {
+        clearTimeout(timeout);
+        window.off('closed', handleClosed);
+        this.log.error(
+          c.red(`Failed to close Invoke UI window: ${error instanceof Error ? error.message : error}\r\n`)
+        );
+        resolve(false);
+      }
+    });
+
+    this.windowsClosingWithoutExiting.delete(window);
+
+    if (!closed) {
+      return false;
+    }
+
+    if (this.window === window) {
+      this.window = null;
+    }
+
+    return true;
   };
 
   /**
@@ -439,9 +496,11 @@ export class InvokeManager {
    */
   killProcess = async (): Promise<void> => {
     if (!this.commandRunner.isRunning()) {
+      this.lastRunningData = null;
       return;
     }
     await this.commandRunner.kill(10_000);
+    this.lastRunningData = null;
   };
 }
 

--- a/src/renderer/features/LaunchFlow/LaunchFlowRunning.tsx
+++ b/src/renderer/features/LaunchFlow/LaunchFlowRunning.tsx
@@ -25,6 +25,10 @@ const reopenWindow = async () => {
   await emitter.invoke('invoke-process:reopen-window');
 };
 
+const restartWindow = async () => {
+  await emitter.invoke('invoke-process:restart-window');
+};
+
 export const LaunchFlowRunning = memo(() => {
   const invokeProcessStatus = useStore($invokeProcessStatus);
   const isInvokeProcessPendingDismissal = useStore($isInvokeProcessPendingDismissal);
@@ -48,14 +52,19 @@ export const LaunchFlowRunning = memo(() => {
           </Button>
         )}
         {!isInvokeProcessPendingDismissal && invokeProcessStatus.type !== 'window-crashed' && (
-          <Button
-            onClick={quit}
-            isLoading={invokeProcessStatus.type === 'exiting'}
-            loadingText="Shutting down"
-            colorScheme="error"
-          >
-            Shutdown
-          </Button>
+          <>
+            <Button onClick={restartWindow} colorScheme="invokeGreen">
+              Restart Window
+            </Button>
+            <Button
+              onClick={quit}
+              isLoading={invokeProcessStatus.type === 'exiting'}
+              loadingText="Shutting down"
+              colorScheme="error"
+            >
+              Shutdown
+            </Button>
+          </>
         )}
         {!isInvokeProcessPendingDismissal && invokeProcessStatus.type === 'window-crashed' && (
           <Button onClick={reopenWindow} colorScheme="invokeGreen">

--- a/src/renderer/features/LaunchFlow/LaunchFlowRunning.tsx
+++ b/src/renderer/features/LaunchFlow/LaunchFlowRunning.tsx
@@ -1,6 +1,6 @@
 import { Button, Heading, Text, VStack } from '@invoke-ai/ui-library';
 import { useStore } from '@nanostores/react';
-import { memo } from 'react';
+import { memo, useCallback, useState } from 'react';
 
 import { BodyContainer, BodyContent, BodyFooter } from '@/renderer/common/layout';
 import { LaunchFlowLogViewer } from '@/renderer/features/LaunchFlow/LaunchFlowLogViewer';
@@ -10,6 +10,7 @@ import {
   teardownTerminal,
 } from '@/renderer/features/LaunchFlow/state';
 import { emitter } from '@/renderer/services/ipc';
+import { persistedStoreApi } from '@/renderer/services/store';
 
 const quit = async () => {
   await emitter.invoke('invoke-process:exit-invoke');
@@ -32,6 +33,18 @@ const restartWindow = async () => {
 export const LaunchFlowRunning = memo(() => {
   const invokeProcessStatus = useStore($invokeProcessStatus);
   const isInvokeProcessPendingDismissal = useStore($isInvokeProcessPendingDismissal);
+  const { serverMode } = useStore(persistedStoreApi.$atom);
+  const [isRestartingWindow, setIsRestartingWindow] = useState(false);
+  const canRestartWindow = invokeProcessStatus.type === 'running' && !serverMode;
+
+  const restart = useCallback(async () => {
+    setIsRestartingWindow(true);
+    try {
+      await restartWindow();
+    } finally {
+      setIsRestartingWindow(false);
+    }
+  }, []);
 
   return (
     <BodyContainer>
@@ -51,20 +64,31 @@ export const LaunchFlowRunning = memo(() => {
             Back
           </Button>
         )}
-        {!isInvokeProcessPendingDismissal && invokeProcessStatus.type !== 'window-crashed' && (
+        {!isInvokeProcessPendingDismissal && canRestartWindow && (
           <>
-            <Button onClick={restartWindow} colorScheme="invokeGreen">
+            <Button
+              onClick={restart}
+              isLoading={isRestartingWindow}
+              loadingText="Restarting"
+              isDisabled={isRestartingWindow}
+              colorScheme="invokeGreen"
+            >
               Restart Window
             </Button>
-            <Button
-              onClick={quit}
-              isLoading={invokeProcessStatus.type === 'exiting'}
-              loadingText="Shutting down"
-              colorScheme="error"
-            >
+            <Button onClick={quit} isDisabled={isRestartingWindow} colorScheme="error">
               Shutdown
             </Button>
           </>
+        )}
+        {!isInvokeProcessPendingDismissal && !canRestartWindow && invokeProcessStatus.type !== 'window-crashed' && (
+          <Button
+            onClick={quit}
+            isLoading={invokeProcessStatus.type === 'exiting'}
+            loadingText="Shutting down"
+            colorScheme="error"
+          >
+            Shutdown
+          </Button>
         )}
         {!isInvokeProcessPendingDismissal && invokeProcessStatus.type === 'window-crashed' && (
           <Button onClick={reopenWindow} colorScheme="invokeGreen">

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -321,6 +321,7 @@ type InvokeProcessIpcEvents = Namespaced<
     'start-invoke': (location: string) => void;
     'exit-invoke': () => void;
     'reopen-window': () => void;
+    'restart-window': () => void;
     resize: (cols: number, rows: number) => void;
   }
 >;


### PR DESCRIPTION
This PR adds a **Restart Window** action that recreates only the Invoke UI browser window without stopping the running backend server.

This is useful during long sessions with many generation iterations, where the UI can start feeling sluggish and generation previews may take longer to appear. Restarting just the window gives users a quick way to refresh the UI state without interrupting the server or requiring a full Invoke restart.