### PR TITLE
fix(ci): pin Windows build runner

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -145,7 +145,7 @@ jobs:
             dist/*.yaml
 
   build-windows:
-    runs-on: windows-latest
+    runs-on: windows-2022
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
## Summary

This PR pins the unsigned Windows build job to `windows-2022` instead of `windows-latest`.

## Why

`windows-latest` now resolves to the newer `windows-2025-vs2026` runner image. That image provides Visual Studio 18, which the current Electron `node-gyp` dependency does not recognize during native module rebuilds.

This causes the Windows build to fail during `npm ci` while rebuilding `node-pty`:

```text
unsupported version: 18
invalid versionYear: undefined
Could not find any Visual Studio installation to use