### PR TITLE
chore(ci): expire unsigned build artifacts after 7 days

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -81,6 +81,7 @@ jobs:
             dist/*.blockmap
             dist/*.yml
             dist/*.yaml
+          retention-days: 7
 
   build-macos:
     runs-on: macos-latest
@@ -143,6 +144,7 @@ jobs:
             dist/*.blockmap
             dist/*.yml
             dist/*.yaml
+          retention-days: 7
 
   build-windows:
     runs-on: windows-latest
@@ -204,3 +206,4 @@ jobs:
             dist/*.blockmap
             dist/*.yml
             dist/*.yaml
+          retention-days: 7


### PR DESCRIPTION
## Summary

GitHub warned that the invoke-ai org has used 90% of its Actions storage quota. Nearly all of it (~26 GB) was live unsigned installer artifacts in this repo: `build.yml` uploads ~1 GB per CI run (linux ~270 MB, macos ~490 MB, windows ~210 MB) with no `retention-days`, so every build's artifacts lingered for the 90-day default.

This PR sets `retention-days: 7` on the three unsigned upload steps in `build.yml`. The unsigned artifacts are only needed briefly after a build for signing and testing — actual releases live in GitHub Releases.

The signed-artifact uploads in `build-and-sign.yml` and `wait-signature.yml` are left at their explicit 90-day retention, since those look intentional for the release flow.

Note: artifacts older than 2 days were also deleted directly via the API (~21 GB freed); this change keeps the quota from filling back up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)