### PR TITLE
chore: bump bundled uv from 0.6.12 to 0.11.28

### DIFF
--- a/package.json
+++ b/package.json
@@ -126,16 +126,16 @@
   },
   "uv": {
     "linux": {
-      "url": "https://github.com/astral-sh/uv/releases/download/0.11.21/uv-x86_64-unknown-linux-gnu.tar.gz",
-      "sha256": "8c88519b0ef0af9801fcdee419bbb12116bd9e6b18e162ae093c932d8b264050"
+      "url": "https://github.com/astral-sh/uv/releases/download/0.11.28/uv-x86_64-unknown-linux-gnu.tar.gz",
+      "sha256": "e490a6464492183c5d4534a5527fb4440f7f2bb2f228162ad7e4afe076dc0224"
     },
     "win": {
-      "url": "https://github.com/astral-sh/uv/releases/download/0.11.21/uv-x86_64-pc-windows-msvc.zip",
-      "sha256": "ace861f360c6de2babedc1607d0f454b6b09a820dbc8182dc15af927e4df9589"
+      "url": "https://github.com/astral-sh/uv/releases/download/0.11.28/uv-x86_64-pc-windows-msvc.zip",
+      "sha256": "0a23463216d09c6a72ff80ef5dc5a795f07dc1575cb84d24596c2f124a441b7b"
     },
     "mac": {
-      "url": "https://github.com/astral-sh/uv/releases/download/0.11.21/uv-aarch64-apple-darwin.tar.gz",
-      "sha256": "1f921d491ba5ffeea774eb04d6681ecee379101341cbb1500394993b541bf3f4"
+      "url": "https://github.com/astral-sh/uv/releases/download/0.11.28/uv-aarch64-apple-darwin.tar.gz",
+      "sha256": "33540eb7c883ab857eff79bd5ac2aa31fe27b595abecb4a9c003a2c998447232"
     }
   },
   "peerDependencies": {


### PR DESCRIPTION
## Summary

Bumps the bundled uv from 0.6.12 (over a year old) to 0.11.28. The old version fails to parse newer `~/.config/uv/uv.toml` files, as reported in #131. This addresses the uv-version half of that issue; the `uv.lock` half is handled by the bootstrap-install work already on `main`.

## Changes

- `package.json`: uv download URLs and sha256s updated to 0.11.28 for linux/win/mac. Checksums are taken from the official `.sha256` release assets and were independently verified by downloading and hashing all three archives.

## Compatibility

Every flag the launcher passes to uv was exercised against 0.11 with real invocations and is still accepted:

- `uv venv --relocatable --prompt invoke --python 3.12 --python-preference only-managed`
- `uv pip install --python-preference only-managed --force-reinstall --compile-bytecode` (and the bootstrap path's `--no-deps`)
- `uv sync --frozen --no-install-project --active --inexact --compile-bytecode`
- `uv python install --python-preference only-managed --reinstall`

Note `--python-preference` and `--force-reinstall` no longer appear in `--help` (they're hidden aliases now) but still parse and behave correctly.

## QA

- `npm run download -- linux` downloads, checksum-verifies, and extracts the binary; `assets/bin/uv --version` reports `uv 0.11.28 (x86_64-unknown-linux-gnu)`.

Related: #131

🤖 Generated with [Claude Code](https://claude.com/claude-code)
