### PR TITLE
feat: minimize launcher to system tray after startup

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -48,6 +48,8 @@ const [invoke, cleanupInvoke] = createInvokeManager({
   store,
   ipc: main.ipc,
   sendToWindow: main.sendToWindow,
+  // Let the main process manager drive tray behavior (auto-hide/restore/quit) based on the Invoke status.
+  onStatusChange: main.handleInvokeStatusChange,
 });
 
 main.ipc.handle('main-process:get-status', () => main.getStatus());

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -67,6 +67,10 @@ const [invoke, cleanupInvoke] = createInvokeManager({
   onStatusChange: main.handleInvokeStatusChange,
 });
 
+// Give the close-confirmation the real Invoke window state (not a stale serverMode guess), so it tells the truth about
+// whether closing the launcher will shut Invoke down.
+main.setInvokeWindowChecker(invoke.hasWindow);
+
 main.ipc.handle('main-process:get-status', () => main.getStatus());
 main.ipc.handle('install-process:get-status', () => install.getStatus());
 main.ipc.handle('invoke-process:get-status', () => invoke.getStatus());

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -34,6 +34,19 @@ app.commandLine.appendSwitch('disable-backing-store-limit');
 const main = new MainProcessManager({ store });
 let isShuttingDown = false;
 
+// Only allow a single instance. Without this, once the launcher is hidden to the tray (and especially if the tray icon
+// failed to render), relaunching from the desktop would start a second instance contending for the same electron-store
+// file and install directory while the first runs invisibly. Instead, a second launch focuses/restores the existing
+// window.
+const gotSingleInstanceLock = app.requestSingleInstanceLock();
+if (!gotSingleInstanceLock) {
+  app.quit();
+} else {
+  app.on('second-instance', () => {
+    main.focusOrRestore();
+  });
+}
+
 // Create ConsoleManager for terminal functionality
 const [, cleanupConsole] = createConsoleManager({
   ipc: main.ipc,
@@ -43,6 +56,8 @@ const [, cleanupConsole] = createConsoleManager({
 const [install, cleanupInstall] = createInstallManager({
   ipc: main.ipc,
   sendToWindow: main.sendToWindow,
+  // Restore the launcher if the user manually minimized it during an install that then finished or failed.
+  onStatusChange: main.handleInstallStatusChange,
 });
 const [invoke, cleanupInvoke] = createInvokeManager({
   store,
@@ -82,9 +97,15 @@ async function cleanup() {
 
 /**
  * This method will be called when Electron has finished initialization and is ready to create browser windows.
- * Some APIs can only be used after this event occurs.
+ * Some APIs can only be used after this event occurs. A non-primary instance is on its way to quitting, so it must not
+ * create a window.
  */
-app.on('ready', main.createWindow);
+app.on('ready', () => {
+  if (!gotSingleInstanceLock) {
+    return;
+  }
+  main.createWindow();
+});
 
 /**
  * Quit when all windows are closed.

--- a/src/main/install-manager.ts
+++ b/src/main/install-manager.ts
@@ -697,7 +697,13 @@ export const createInstallManager = (arg: {
   });
 
   ipc.handle('install-process:start-install', (_, installationPath, gpuType, version, repair) => {
-    installManager.startInstall(installationPath, gpuType, version, repair);
+    // startInstall has unguarded throws after it sets `starting`/`installing` (platform assert, env resolution). If one
+    // escapes, the status would pin at an active value forever, wrongly reporting "install in progress". Catch here and
+    // surface it as an error so the status is accurate.
+    installManager.startInstall(installationPath, gpuType, version, repair).catch((error) => {
+      const message = error instanceof Error ? error.message : String(error);
+      installManager.updateStatus({ type: 'error', error: { message } });
+    });
   });
   ipc.handle('install-process:cancel-install', async () => {
     await installManager.cancelInstall();

--- a/src/main/install-manager.ts
+++ b/src/main/install-manager.ts
@@ -679,6 +679,7 @@ export class InstallManager {
 export const createInstallManager = (arg: {
   ipc: IpcListener<IpcEvents>;
   sendToWindow: <T extends keyof IpcRendererEvents>(channel: T, ...args: IpcRendererEvents[T]) => void;
+  onStatusChange?: (status: WithTimestamp<InstallProcessStatus>) => void;
 }) => {
   const { ipc, sendToWindow } = arg;
 
@@ -691,6 +692,7 @@ export const createInstallManager = (arg: {
     },
     onStatusChange: (status) => {
       sendToWindow('install-process:status', status);
+      arg.onStatusChange?.(status);
     },
   });
 

--- a/src/main/invoke-manager.ts
+++ b/src/main/invoke-manager.ts
@@ -397,6 +397,7 @@ export const createInvokeManager = (arg: {
   store: Store<StoreData>;
   ipc: IpcListener<IpcEvents>;
   sendToWindow: <T extends keyof IpcRendererEvents>(channel: T, ...args: IpcRendererEvents[T]) => void;
+  onStatusChange?: (status: WithTimestamp<InvokeProcessStatus>) => void;
 }) => {
   const { store, ipc, sendToWindow } = arg;
   const invokeManager = new InvokeManager({
@@ -406,6 +407,7 @@ export const createInvokeManager = (arg: {
     },
     onStatusChange: (status) => {
       sendToWindow('invoke-process:status', status);
+      arg.onStatusChange?.(status);
     },
     sendClearLogs: () => {
       sendToWindow('invoke-process:clear-logs');

--- a/src/main/invoke-manager.ts
+++ b/src/main/invoke-manager.ts
@@ -189,20 +189,24 @@ export class InvokeManager {
               this.log.info(c.green.bold('Invoke shut down normally\r\n'));
               return;
             }
-            if (exitCode === 0) {
-              // Process exited on its own with no error
-              this.updateStatus({ type: 'exited' });
-              this.log.info(c.green.bold('Invoke process exited normally\r\n'));
-            } else if (signal !== undefined && signal !== null) {
-              // Process was killed via signal without us asking for it (the intentional-shutdown case is handled by the
+            // NOTE ON node-pty EXIT SEMANTICS: node-pty reports a signal-terminated child as `{ exitCode: 0, signal: N }`
+            // and a clean exit as `{ exitCode: N, signal: 0 }` (on Windows `signal` is `undefined`). So we must test
+            // `signal` truthily *and first* - otherwise `exitCode === 0` swallows every signal kill, and the sentinel
+            // `signal: 0` on a normal non-zero exit gets misreported as "terminated with signal 0".
+            if (signal) {
+              // The process was killed by a signal we didn't ask for (the intentional-shutdown case is caught by the
               // `exiting` branch above). This is an abnormal termination - e.g. the OOM killer or a segfault during
-              // model load - so surface it as an error rather than a clean exit, so the launcher is restored instead
-              // of quitting and the logs stay available.
+              // model load - so surface it as an error, not a clean exit, so the launcher is restored instead of
+              // quitting and the logs stay available.
               this.updateStatus({
                 type: 'error',
                 error: { message: `Process was terminated with signal ${signal}` },
               });
               this.log.info(c.red(`Invoke process was terminated with signal ${signal}, exit code ${exitCode}\r\n`));
+            } else if (exitCode === 0) {
+              // Process exited on its own with no error
+              this.updateStatus({ type: 'exited' });
+              this.log.info(c.green.bold('Invoke process exited normally\r\n'));
             } else if (exitCode !== null) {
               // Process exited on its own, with a non-zero code, indicating an error
               this.updateStatus({ type: 'error', error: { message: `Process exited with code ${exitCode}` } });
@@ -390,6 +394,15 @@ export class InvokeManager {
    */
   isProcessRunning = (): boolean => {
     return this.commandRunner.isRunning();
+  };
+
+  /**
+   * Whether Invoke currently has its own live UI window. This is the source of truth for "does closing the launcher
+   * take Invoke down with it" - it is false during startup, in server mode (no window is ever created), and after the
+   * window has crashed, and only true once a real desktop-mode window exists.
+   */
+  hasWindow = (): boolean => {
+    return this.window !== null && !this.window.isDestroyed();
   };
 
   /**

--- a/src/main/invoke-manager.ts
+++ b/src/main/invoke-manager.ts
@@ -194,9 +194,15 @@ export class InvokeManager {
               this.updateStatus({ type: 'exited' });
               this.log.info(c.green.bold('Invoke process exited normally\r\n'));
             } else if (signal !== undefined && signal !== null) {
-              // Process was killed via signal
-              this.updateStatus({ type: 'exited' });
-              this.log.info(c.yellow(`Invoke process was terminated with signal ${signal}, exit code ${exitCode}\r\n`));
+              // Process was killed via signal without us asking for it (the intentional-shutdown case is handled by the
+              // `exiting` branch above). This is an abnormal termination - e.g. the OOM killer or a segfault during
+              // model load - so surface it as an error rather than a clean exit, so the launcher is restored instead
+              // of quitting and the logs stay available.
+              this.updateStatus({
+                type: 'error',
+                error: { message: `Process was terminated with signal ${signal}` },
+              });
+              this.log.info(c.red(`Invoke process was terminated with signal ${signal}, exit code ${exitCode}\r\n`));
             } else if (exitCode !== null) {
               // Process exited on its own, with a non-zero code, indicating an error
               this.updateStatus({ type: 'error', error: { message: `Process exited with code ${exitCode}` } });
@@ -379,6 +385,14 @@ export class InvokeManager {
   };
 
   /**
+   * Whether the underlying Invoke process is currently running. This is independent of the UI window - e.g. after a
+   * window crash the process is still alive.
+   */
+  isProcessRunning = (): boolean => {
+    return this.commandRunner.isRunning();
+  };
+
+  /**
    * Kill the Invoke process and wait for it to exit
    */
   killProcess = async (): Promise<void> => {
@@ -431,12 +445,15 @@ export const createInvokeManager = (arg: {
   });
 
   const cleanupInvokeManager = async () => {
-    const status = invokeManager.getStatus();
-    if (status.type === 'running' || status.type === 'starting') {
+    // Shut down Invoke whenever the process is still alive, regardless of status. Gating on specific statuses missed
+    // the `window-crashed` case (process alive, UI window gone), which would orphan the Python process, leave uvicorn
+    // bound to its port, and strand VRAM after the launcher quit.
+    if (invokeManager.isProcessRunning()) {
       await invokeManager.exitInvoke();
     }
     ipcMain.removeHandler('invoke-process:start-invoke');
     ipcMain.removeHandler('invoke-process:exit-invoke');
+    ipcMain.removeHandler('invoke-process:reopen-window');
     ipcMain.removeHandler('invoke-process:resize');
   };
 

--- a/src/main/main-process-manager.ts
+++ b/src/main/main-process-manager.ts
@@ -1,12 +1,21 @@
 import { IpcEmitter, IpcListener } from '@electron-toolkit/typed-ipc/main';
-import { app, BrowserWindow, shell } from 'electron';
+import { app, BrowserWindow, dialog, Menu, nativeImage, shell, Tray } from 'electron';
 import contextMenu from 'electron-context-menu';
 import type Store from 'electron-store';
 import path from 'path';
 
 import { isDevelopment, manageWindowSize } from '@/main/util';
-import type { IpcEvents, IpcRendererEvents, MainProcessStatus, StoreData, WithTimestamp } from '@/shared/types';
+import type {
+  InvokeProcessStatus,
+  IpcEvents,
+  IpcRendererEvents,
+  MainProcessStatus,
+  StoreData,
+  WithTimestamp,
+} from '@/shared/types';
 
+// electron-vite resolves this to the icon's runtime path, copying the file into the build output.
+import trayIconPath from '../../assets/images/invoke-avatar-square.png?asset';
 import { checkForUpdates } from './updater';
 
 const NOT_INITIALIZED_MESSAGE = 'Main window is not initialized';
@@ -15,6 +24,14 @@ export class MainProcessManager {
   private window: BrowserWindow | null;
   private status: WithTimestamp<MainProcessStatus>;
   private store: Store<StoreData>;
+  /** The system tray icon, present only while the launcher is hidden to the tray. */
+  private tray: Tray | null;
+  /** Whether the launcher window is currently hidden to the system tray. */
+  private isHiddenToTray: boolean;
+  /** Whether the application is in the process of quitting. Used to skip the close-confirmation dialog. */
+  private isQuitting: boolean;
+  /** The last known Invoke process status type. Used to decide whether to confirm closing the launcher. */
+  private invokeStatusType: InvokeProcessStatus['type'] | null;
 
   ipc: IpcListener<IpcEvents>;
   emitter: IpcEmitter<IpcRendererEvents>;
@@ -26,6 +43,14 @@ export class MainProcessManager {
     this.emitter = new IpcEmitter<IpcRendererEvents>();
     this.status = { type: 'initializing', timestamp: Date.now() };
     this.store = store;
+    this.tray = null;
+    this.isHiddenToTray = false;
+    this.isQuitting = false;
+    this.invokeStatusType = null;
+
+    app.on('before-quit', () => {
+      this.isQuitting = true;
+    });
     this.store.onDidAnyChange((data) => {
       this.sendToWindow('store:changed', data);
     });
@@ -37,6 +62,9 @@ export class MainProcessManager {
     });
     this.ipc.handle('store:reset', (_) => {
       this.store.clear();
+    });
+    this.ipc.handle('main-process:hide-to-tray', () => {
+      this.hideToTray();
     });
 
     contextMenu({
@@ -104,6 +132,34 @@ export class MainProcessManager {
       checkForUpdates(window);
     });
 
+    // If the user closes the launcher window while Invoke is still running, confirm first. Closing the launcher hides
+    // access to the logs and controls, which is easy to do by accident.
+    window.on('close', (event) => {
+      if (this.isQuitting || this.isHiddenToTray) {
+        return;
+      }
+      const isInvokeActive =
+        this.invokeStatusType === 'running' ||
+        this.invokeStatusType === 'starting' ||
+        this.invokeStatusType === 'window-crashed';
+      if (!isInvokeActive) {
+        return;
+      }
+      const choice = dialog.showMessageBoxSync(window, {
+        type: 'question',
+        buttons: ['Cancel', 'Close Launcher'],
+        defaultId: 0,
+        cancelId: 0,
+        title: 'Close Launcher?',
+        message: 'Invoke is still running.',
+        detail:
+          'Closing the launcher hides access to the logs and controls. Invoke itself will keep running. Are you sure you want to close the launcher?',
+      });
+      if (choice === 0) {
+        event.preventDefault();
+      }
+    });
+
     // Disable a few things in production
     if (!isDevelopment()) {
       // Prevent navigation and page reload
@@ -164,7 +220,97 @@ export class MainProcessManager {
     this.window = null;
   };
 
+  /**
+   * React to Invoke process status changes to drive the tray behavior.
+   * - When Invoke starts successfully, hide the launcher to the tray (if enabled and not in server mode).
+   * - When Invoke shuts down normally while hidden, quit the launcher entirely.
+   * - When Invoke errors or its window crashes while hidden, restore the launcher so the user can see what happened.
+   */
+  handleInvokeStatusChange = (status: WithTimestamp<InvokeProcessStatus>): void => {
+    this.invokeStatusType = status.type;
+
+    switch (status.type) {
+      case 'running': {
+        // Hide once Invoke is up. This applies in server mode too - the tray icon is exactly the point there, since the
+        // launcher is the only window and the user wants it out of the way while the server runs in the background.
+        if (this.store.get('hideLauncherAfterStartup')) {
+          this.hideToTray();
+        }
+        break;
+      }
+      case 'exited': {
+        // Invoke shut down normally. If the launcher was hidden to the tray, the user is done - quit entirely.
+        if (this.isHiddenToTray) {
+          app.quit();
+        }
+        break;
+      }
+      case 'error':
+      case 'window-crashed': {
+        // Something went wrong - bring the launcher back so the user can read the logs and recover.
+        if (this.isHiddenToTray) {
+          this.showFromTray();
+        }
+        break;
+      }
+      default:
+        break;
+    }
+  };
+
+  /**
+   * Hide the launcher window to the system tray, creating the tray icon if necessary.
+   */
+  hideToTray = (): void => {
+    if (!this.window || this.window.isDestroyed() || this.isHiddenToTray) {
+      return;
+    }
+    this.createTray();
+    this.window.hide();
+    this.isHiddenToTray = true;
+  };
+
+  /**
+   * Restore the launcher window from the system tray and remove the tray icon.
+   */
+  showFromTray = (): void => {
+    this.isHiddenToTray = false;
+    this.destroyTray();
+    if (!this.window || this.window.isDestroyed()) {
+      return;
+    }
+    this.window.show();
+    this.window.focus();
+  };
+
+  private createTray = (): void => {
+    if (this.tray) {
+      return;
+    }
+    const image = nativeImage.createFromPath(trayIconPath).resize({ width: 16, height: 16 });
+    const tray = new Tray(image.isEmpty() ? trayIconPath : image);
+    tray.setToolTip('Invoke Community Edition');
+    const contextMenu = Menu.buildFromTemplate([
+      { label: 'Show Launcher', click: this.showFromTray },
+      { type: 'separator' },
+      { label: 'Quit', click: () => app.quit() },
+    ]);
+    tray.setContextMenu(contextMenu);
+    // Restoring on click is the expected behavior on Windows/Linux; harmless on macOS where the menu opens on click.
+    tray.on('click', this.showFromTray);
+    tray.on('double-click', this.showFromTray);
+    this.tray = tray;
+  };
+
+  private destroyTray = (): void => {
+    if (this.tray) {
+      this.tray.destroy();
+      this.tray = null;
+    }
+  };
+
   cleanup = () => {
+    this.destroyTray();
     this.closeWindow();
   };
 }

--- a/src/main/main-process-manager.ts
+++ b/src/main/main-process-manager.ts
@@ -42,6 +42,16 @@ export class MainProcessManager {
   private invokeStatusType: InvokeProcessStatus['type'] | null;
   /** The last known install process status type. Used to decide whether to confirm closing and to restore on finish. */
   private installStatusType: InstallProcessStatus['type'] | null;
+  /** Whether tray creation has already failed once (some platforms have no tray host). Avoids re-throwing every call. */
+  private trayCreationFailed: boolean;
+  /** Guards the one-time update check so recreating the launcher window does not re-prompt. */
+  private hasCheckedForUpdates: boolean;
+  /**
+   * Source of truth for whether Invoke currently has its own window. Injected from the Invoke manager (see
+   * {@link setInvokeWindowChecker}) so the close-confirmation reflects reality rather than re-reading `serverMode`,
+   * which the user can toggle mid-session.
+   */
+  private invokeHasWindow: () => boolean;
 
   ipc: IpcListener<IpcEvents>;
   emitter: IpcEmitter<IpcRendererEvents>;
@@ -59,6 +69,9 @@ export class MainProcessManager {
     this.isQuitting = false;
     this.invokeStatusType = null;
     this.installStatusType = null;
+    this.trayCreationFailed = false;
+    this.hasCheckedForUpdates = false;
+    this.invokeHasWindow = () => false;
 
     app.on('before-quit', () => {
       this.isQuitting = true;
@@ -147,9 +160,21 @@ export class MainProcessManager {
     window.once('ready-to-show', () => {
       this.updateStatus({ type: 'idle' });
       window.show();
-      // If auto-hide fires during a slow update download, make sure the launcher is visible again before showing the
-      // blocking "restart to install" prompt - otherwise it would attach to a hidden window.
-      checkForUpdates(window, this.focusOrRestore);
+      // Only check for updates once per app run, not every time the launcher window is (re)created. The updater shows
+      // its own top-level dialogs, so it does not depend on this window being visible.
+      if (!this.hasCheckedForUpdates) {
+        this.hasCheckedForUpdates = true;
+        checkForUpdates();
+      }
+    });
+
+    // Null out our reference when the window is actually destroyed, so recovery paths know to recreate it rather than
+    // poking a dead window. Without this, closing the launcher in desktop mode (Invoke keeps the app alive) would leave
+    // every restore route a no-op.
+    window.on('closed', () => {
+      if (this.window === window) {
+        this.window = null;
+      }
     });
 
     // If the user closes the launcher window while work is in progress, confirm first - and tell them what will
@@ -303,11 +328,12 @@ export class MainProcessManager {
   };
 
   /**
-   * Whether Invoke currently has its own window keeping the app alive. This is only the case in desktop mode once
-   * running - never during startup, never after the Invoke window crashed, and never in server mode.
+   * Inject the source of truth for whether Invoke currently has a live window. Wired from the Invoke manager so the
+   * close-confirmation reflects the real window state instead of re-deriving it from `serverMode` (which the user can
+   * toggle mid-session, making the dialog lie in both directions).
    */
-  private doesInvokeWindowExist = (): boolean => {
-    return this.invokeStatusType === 'running' && !this.store.get('serverMode');
+  setInvokeWindowChecker = (hasWindow: () => boolean): void => {
+    this.invokeHasWindow = hasWindow;
   };
 
   /**
@@ -324,7 +350,7 @@ export class MainProcessManager {
       return null;
     }
 
-    if (this.doesInvokeWindowExist()) {
+    if (this.invokeHasWindow()) {
       // The Invoke window keeps the process alive, so closing the launcher just loses the logs/controls.
       return 'The Invoke window will stay open and Invoke will keep running, but you will lose access to the launcher and its logs. Close the launcher anyway?';
     }
@@ -344,12 +370,14 @@ export class MainProcessManager {
     if (!this.window || this.window.isDestroyed() || this.isHiddenToTray) {
       return;
     }
-    if (!this.createTray()) {
-      // No usable tray - minimizing keeps the window reachable rather than hiding it into nothing.
+    if (this.createTray()) {
+      this.window.hide();
+    } else {
+      // No usable tray host - fall back to a normal minimize so the window stays reachable from the taskbar/Dock. We
+      // still track the hidden/auto state so the contract (restore-on-crash, quit-on-normal-shutdown) holds; only the
+      // presentation degrades from "hidden to tray" to "minimized".
       this.window.minimize();
-      return;
     }
-    this.window.hide();
     this.isHiddenToTray = true;
     this.autoHiddenAfterStartup = options?.auto ?? false;
   };
@@ -374,8 +402,9 @@ export class MainProcessManager {
   };
 
   /**
-   * Bring the launcher window to the foreground from the tray, a minimized state, or the background. Used for the
-   * single-instance relaunch and the macOS Dock/activate handlers.
+   * Bring the launcher window to the foreground from the tray, a minimized state, or the background. If the window was
+   * closed entirely (e.g. in desktop mode where the Invoke window keeps the app alive), recreate it - otherwise the
+   * single-instance relaunch and the macOS Dock/activate handlers would silently do nothing, leaving no route back.
    */
   focusOrRestore = (): void => {
     if (this.isHiddenToTray) {
@@ -384,6 +413,7 @@ export class MainProcessManager {
     }
     const window = this.window;
     if (!window || window.isDestroyed()) {
+      this.createWindow();
       return;
     }
     if (window.isMinimized()) {
@@ -402,21 +432,26 @@ export class MainProcessManager {
     if (this.tray) {
       return true;
     }
+    if (this.trayCreationFailed) {
+      // We already tried and the platform threw - don't reconstruct and re-throw on every hide.
+      return false;
+    }
     try {
-      // Hand Electron the full-resolution image and let it pick the representation for the current DPI, rather than
-      // baking in a single upscaled 16x16 bitmap.
+      // Hand Electron the full-resolution RGBA icon rather than a pre-scaled bitmap. There is only a single 1x
+      // representation, so this is about the alpha channel and letting Electron do the downscale, not multi-DPI.
       const image = nativeImage.createFromPath(trayIconPath);
       const tray = new Tray(image);
       tray.setToolTip('Invoke Community Edition');
+      // All restore paths are deferred out of the tray's own event/menu callbacks via setImmediate, so we never destroy
+      // the tray from inside one of its handlers.
       const contextMenu = Menu.buildFromTemplate([
         { label: 'Show Launcher', click: () => setImmediate(this.showFromTray) },
         { type: 'separator' },
-        { label: 'Quit', click: () => app.quit() },
+        { label: 'Quit', click: () => setImmediate(() => app.quit()) },
       ]);
       tray.setContextMenu(contextMenu);
       // On Windows/Linux a left click should restore the window. On macOS a click opens the context menu, so we don't
-      // bind it there and rely on the "Show Launcher" item and the Dock instead. Restoring is deferred out of the event
-      // callback so we don't destroy the tray from within its own handler.
+      // bind it there and rely on the "Show Launcher" item and the Dock instead.
       if (process.platform !== 'darwin') {
         tray.on('click', () => setImmediate(this.showFromTray));
         tray.on('double-click', () => setImmediate(this.showFromTray));
@@ -425,6 +460,7 @@ export class MainProcessManager {
       return true;
     } catch (error) {
       console.error('Failed to create system tray icon:', error);
+      this.trayCreationFailed = true;
       return false;
     }
   };

--- a/src/main/main-process-manager.ts
+++ b/src/main/main-process-manager.ts
@@ -129,9 +129,10 @@ export class MainProcessManager {
   };
 
   createWindow = () => {
-    // Never build a window in a process that doesn't hold the single-instance lock. A non-primary instance is on its way
-    // to quitting, and the activate/second-instance paths can reach this before that bail-out completes.
-    if (!app.hasSingleInstanceLock()) {
+    // Don't build a window we shouldn't. A non-primary instance (no single-instance lock) is on its way out; and the
+    // primary can still reach this via activate/second-instance during its own async shutdown. `hasSingleInstanceLock()`
+    // is not a "not quitting" test (the lock is held until exit), so we check `isQuitting` explicitly too.
+    if (!app.hasSingleInstanceLock() || this.isQuitting) {
       return;
     }
 
@@ -419,6 +420,11 @@ export class MainProcessManager {
     // Check for a gone window FIRST. If the launcher was closed (desktop mode keeps Invoke's window alive), recreate it -
     // this must win over the tray branch, since showFromTray() gives up on a null window and would leave no route back.
     if (!window || window.isDestroyed()) {
+      // Reset hide state defensively so the fresh window can't inherit stale hidden/auto flags, which would re-suppress
+      // the close-confirmation and re-arm quit-on-shutdown.
+      this.isHiddenToTray = false;
+      this.autoHiddenAfterStartup = false;
+      this.destroyTray();
       this.createWindow();
       return;
     }

--- a/src/main/main-process-manager.ts
+++ b/src/main/main-process-manager.ts
@@ -6,6 +6,7 @@ import path from 'path';
 
 import { isDevelopment, manageWindowSize } from '@/main/util';
 import type {
+  InstallProcessStatus,
   InvokeProcessStatus,
   IpcEvents,
   IpcRendererEvents,
@@ -14,8 +15,9 @@ import type {
   WithTimestamp,
 } from '@/shared/types';
 
-// electron-vite resolves this to the icon's runtime path, copying the file into the build output.
-import trayIconPath from '../../assets/images/invoke-avatar-square.png?asset';
+// electron-vite resolves this to the icon's runtime path, copying the file into the build output. We use the RGBA app
+// icon (with a real alpha channel) rather than the opaque avatar square so it reads correctly on a menu bar.
+import trayIconPath from '../../build/icon.png?asset';
 import { checkForUpdates } from './updater';
 
 const NOT_INITIALIZED_MESSAGE = 'Main window is not initialized';
@@ -28,10 +30,18 @@ export class MainProcessManager {
   private tray: Tray | null;
   /** Whether the launcher window is currently hidden to the system tray. */
   private isHiddenToTray: boolean;
+  /**
+   * Whether the launcher was hidden automatically after Invoke started (as opposed to a manual "minimize to tray").
+   * Only an auto-hide arms the "quit when Invoke shuts down normally" behavior - a manual minimize keeps the app
+   * running in the tray.
+   */
+  private autoHiddenAfterStartup: boolean;
   /** Whether the application is in the process of quitting. Used to skip the close-confirmation dialog. */
   private isQuitting: boolean;
-  /** The last known Invoke process status type. Used to decide whether to confirm closing the launcher. */
+  /** The last known Invoke process status type. Used to decide tray behavior and whether to confirm closing. */
   private invokeStatusType: InvokeProcessStatus['type'] | null;
+  /** The last known install process status type. Used to decide whether to confirm closing and to restore on finish. */
+  private installStatusType: InstallProcessStatus['type'] | null;
 
   ipc: IpcListener<IpcEvents>;
   emitter: IpcEmitter<IpcRendererEvents>;
@@ -45,11 +55,19 @@ export class MainProcessManager {
     this.store = store;
     this.tray = null;
     this.isHiddenToTray = false;
+    this.autoHiddenAfterStartup = false;
     this.isQuitting = false;
     this.invokeStatusType = null;
+    this.installStatusType = null;
 
     app.on('before-quit', () => {
       this.isQuitting = true;
+    });
+
+    // On macOS, clicking the Dock icon should bring the launcher back, whether it is hidden to the tray or just closed
+    // to the background. This is also the recovery route if the tray icon failed to render.
+    app.on('activate', () => {
+      this.focusOrRestore();
     });
     this.store.onDidAnyChange((data) => {
       this.sendToWindow('store:changed', data);
@@ -129,31 +147,31 @@ export class MainProcessManager {
     window.once('ready-to-show', () => {
       this.updateStatus({ type: 'idle' });
       window.show();
-      checkForUpdates(window);
+      // If auto-hide fires during a slow update download, make sure the launcher is visible again before showing the
+      // blocking "restart to install" prompt - otherwise it would attach to a hidden window.
+      checkForUpdates(window, this.focusOrRestore);
     });
 
-    // If the user closes the launcher window while Invoke is still running, confirm first. Closing the launcher hides
-    // access to the logs and controls, which is easy to do by accident.
+    // If the user closes the launcher window while work is in progress, confirm first - and tell them what will
+    // actually happen, which depends on whether closing the launcher would take Invoke/the install down with it.
     window.on('close', (event) => {
       if (this.isQuitting || this.isHiddenToTray) {
         return;
       }
-      const isInvokeActive =
-        this.invokeStatusType === 'running' ||
-        this.invokeStatusType === 'starting' ||
-        this.invokeStatusType === 'window-crashed';
-      if (!isInvokeActive) {
+
+      const detail = this.getCloseConfirmationDetail();
+      if (!detail) {
         return;
       }
+
       const choice = dialog.showMessageBoxSync(window, {
         type: 'question',
         buttons: ['Cancel', 'Close Launcher'],
         defaultId: 0,
         cancelId: 0,
         title: 'Close Launcher?',
-        message: 'Invoke is still running.',
-        detail:
-          'Closing the launcher hides access to the logs and controls. Invoke itself will keep running. Are you sure you want to close the launcher?',
+        message: 'Are you sure you want to close the launcher?',
+        detail,
       });
       if (choice === 0) {
         event.preventDefault();
@@ -222,25 +240,28 @@ export class MainProcessManager {
 
   /**
    * React to Invoke process status changes to drive the tray behavior.
-   * - When Invoke starts successfully, hide the launcher to the tray (if enabled and not in server mode).
-   * - When Invoke shuts down normally while hidden, quit the launcher entirely.
+   * - When Invoke first starts successfully, hide the launcher to the tray (if enabled). This applies in server mode
+   *   too - the tray is exactly the point there, since the launcher is the only window.
+   * - When Invoke shuts down normally while it was auto-hidden after startup, quit the launcher entirely.
    * - When Invoke errors or its window crashes while hidden, restore the launcher so the user can see what happened.
    */
   handleInvokeStatusChange = (status: WithTimestamp<InvokeProcessStatus>): void => {
+    const previousStatusType = this.invokeStatusType;
     this.invokeStatusType = status.type;
 
     switch (status.type) {
       case 'running': {
-        // Hide once Invoke is up. This applies in server mode too - the tray icon is exactly the point there, since the
-        // launcher is the only window and the user wants it out of the way while the server runs in the background.
-        if (this.store.get('hideLauncherAfterStartup')) {
-          this.hideToTray();
+        // Only auto-hide on a genuine first start (starting -> running). Reopening the window after a crash goes
+        // window-crashed -> running via reopenWindow(), and must not make the just-restored window vanish again.
+        if (previousStatusType === 'starting' && this.store.get('hideLauncherAfterStartup')) {
+          this.hideToTray({ auto: true });
         }
         break;
       }
       case 'exited': {
-        // Invoke shut down normally. If the launcher was hidden to the tray, the user is done - quit entirely.
-        if (this.isHiddenToTray) {
+        // A normal shutdown (user closed Invoke, or it exited cleanly). Only quit if we auto-hid after startup - a
+        // manual "minimize to tray" should keep the launcher available in the tray instead.
+        if (this.autoHiddenAfterStartup) {
           app.quit();
         }
         break;
@@ -259,15 +280,78 @@ export class MainProcessManager {
   };
 
   /**
-   * Hide the launcher window to the system tray, creating the tray icon if necessary.
+   * React to install process status changes. Installs never auto-hide the launcher, but the user may have manually
+   * minimized it - if an install finishes or fails while hidden, bring the launcher back so the result is visible.
    */
-  hideToTray = (): void => {
+  handleInstallStatusChange = (status: WithTimestamp<InstallProcessStatus>): void => {
+    this.installStatusType = status.type;
+
+    if (this.isHiddenToTray && (status.type === 'completed' || status.type === 'canceled' || status.type === 'error')) {
+      this.showFromTray();
+    }
+  };
+
+  /**
+   * Whether the Invoke process is currently alive (starting up, running, or running-but-window-crashed).
+   */
+  private isInvokeProcessActive = (): boolean => {
+    return (
+      this.invokeStatusType === 'starting' ||
+      this.invokeStatusType === 'running' ||
+      this.invokeStatusType === 'window-crashed'
+    );
+  };
+
+  /**
+   * Whether Invoke currently has its own window keeping the app alive. This is only the case in desktop mode once
+   * running - never during startup, never after the Invoke window crashed, and never in server mode.
+   */
+  private doesInvokeWindowExist = (): boolean => {
+    return this.invokeStatusType === 'running' && !this.store.get('serverMode');
+  };
+
+  /**
+   * Build the confirmation detail text shown when the user tries to close the launcher window, or `null` if no
+   * confirmation is needed. The message reflects what closing the launcher will actually do.
+   */
+  private getCloseConfirmationDetail = (): string | null => {
+    const isInstallActive = this.installStatusType === 'starting' || this.installStatusType === 'installing';
+    if (isInstallActive) {
+      return 'An installation is in progress. Closing the launcher will cancel it. Are you sure you want to continue?';
+    }
+
+    if (!this.isInvokeProcessActive()) {
+      return null;
+    }
+
+    if (this.doesInvokeWindowExist()) {
+      // The Invoke window keeps the process alive, so closing the launcher just loses the logs/controls.
+      return 'The Invoke window will stay open and Invoke will keep running, but you will lose access to the launcher and its logs. Close the launcher anyway?';
+    }
+
+    // The launcher is the only window (server mode, still starting, or the Invoke window crashed), so closing it will
+    // shut Invoke down.
+    return 'Closing the launcher will shut down Invoke. Are you sure you want to continue?';
+  };
+
+  /**
+   * Hide the launcher window to the system tray. If no system tray is available, fall back to a normal minimize so the
+   * window stays recoverable from the taskbar/Dock.
+   *
+   * @param options.auto Whether this hide was triggered automatically after startup (arms quit-on-normal-shutdown).
+   */
+  hideToTray = (options?: { auto?: boolean }): void => {
     if (!this.window || this.window.isDestroyed() || this.isHiddenToTray) {
       return;
     }
-    this.createTray();
+    if (!this.createTray()) {
+      // No usable tray - minimizing keeps the window reachable rather than hiding it into nothing.
+      this.window.minimize();
+      return;
+    }
     this.window.hide();
     this.isHiddenToTray = true;
+    this.autoHiddenAfterStartup = options?.auto ?? false;
   };
 
   /**
@@ -275,35 +359,79 @@ export class MainProcessManager {
    */
   showFromTray = (): void => {
     this.isHiddenToTray = false;
+    this.autoHiddenAfterStartup = false;
     this.destroyTray();
-    if (!this.window || this.window.isDestroyed()) {
+    const window = this.window;
+    if (!window || window.isDestroyed()) {
       return;
     }
-    this.window.show();
-    this.window.focus();
+    // show() alone does not clear a minimized state, so restore first if needed.
+    if (window.isMinimized()) {
+      window.restore();
+    }
+    window.show();
+    window.focus();
   };
 
-  private createTray = (): void => {
-    if (this.tray) {
+  /**
+   * Bring the launcher window to the foreground from the tray, a minimized state, or the background. Used for the
+   * single-instance relaunch and the macOS Dock/activate handlers.
+   */
+  focusOrRestore = (): void => {
+    if (this.isHiddenToTray) {
+      this.showFromTray();
       return;
     }
-    const image = nativeImage.createFromPath(trayIconPath).resize({ width: 16, height: 16 });
-    const tray = new Tray(image.isEmpty() ? trayIconPath : image);
-    tray.setToolTip('Invoke Community Edition');
-    const contextMenu = Menu.buildFromTemplate([
-      { label: 'Show Launcher', click: this.showFromTray },
-      { type: 'separator' },
-      { label: 'Quit', click: () => app.quit() },
-    ]);
-    tray.setContextMenu(contextMenu);
-    // Restoring on click is the expected behavior on Windows/Linux; harmless on macOS where the menu opens on click.
-    tray.on('click', this.showFromTray);
-    tray.on('double-click', this.showFromTray);
-    this.tray = tray;
+    const window = this.window;
+    if (!window || window.isDestroyed()) {
+      return;
+    }
+    if (window.isMinimized()) {
+      window.restore();
+    }
+    window.show();
+    window.focus();
+  };
+
+  /**
+   * Create the system tray icon. Returns whether a tray was successfully created (some platforms have no tray host and
+   * throw here). A tray that "succeeds" but renders nothing on the desktop is still recoverable via the single-instance
+   * lock and the macOS activate handler.
+   */
+  private createTray = (): boolean => {
+    if (this.tray) {
+      return true;
+    }
+    try {
+      // Hand Electron the full-resolution image and let it pick the representation for the current DPI, rather than
+      // baking in a single upscaled 16x16 bitmap.
+      const image = nativeImage.createFromPath(trayIconPath);
+      const tray = new Tray(image);
+      tray.setToolTip('Invoke Community Edition');
+      const contextMenu = Menu.buildFromTemplate([
+        { label: 'Show Launcher', click: () => setImmediate(this.showFromTray) },
+        { type: 'separator' },
+        { label: 'Quit', click: () => app.quit() },
+      ]);
+      tray.setContextMenu(contextMenu);
+      // On Windows/Linux a left click should restore the window. On macOS a click opens the context menu, so we don't
+      // bind it there and rely on the "Show Launcher" item and the Dock instead. Restoring is deferred out of the event
+      // callback so we don't destroy the tray from within its own handler.
+      if (process.platform !== 'darwin') {
+        tray.on('click', () => setImmediate(this.showFromTray));
+        tray.on('double-click', () => setImmediate(this.showFromTray));
+      }
+      this.tray = tray;
+      return true;
+    } catch (error) {
+      console.error('Failed to create system tray icon:', error);
+      return false;
+    }
   };
 
   private destroyTray = (): void => {
     if (this.tray) {
+      this.tray.closeContextMenu();
       this.tray.destroy();
       this.tray = null;
     }

--- a/src/main/main-process-manager.ts
+++ b/src/main/main-process-manager.ts
@@ -129,6 +129,12 @@ export class MainProcessManager {
   };
 
   createWindow = () => {
+    // Never build a window in a process that doesn't hold the single-instance lock. A non-primary instance is on its way
+    // to quitting, and the activate/second-instance paths can reach this before that bail-out completes.
+    if (!app.hasSingleInstanceLock()) {
+      return;
+    }
+
     const window = new BrowserWindow({
       minWidth: 800,
       minHeight: 600,
@@ -160,11 +166,10 @@ export class MainProcessManager {
     window.once('ready-to-show', () => {
       this.updateStatus({ type: 'idle' });
       window.show();
-      // Only check for updates once per app run, not every time the launcher window is (re)created. The updater shows
-      // its own top-level dialogs, so it does not depend on this window being visible.
+      // Only check for updates once per app run, not every time the launcher window is (re)created on a recovery path.
       if (!this.hasCheckedForUpdates) {
         this.hasCheckedForUpdates = true;
-        checkForUpdates();
+        checkForUpdates(window);
       }
     });
 
@@ -371,15 +376,18 @@ export class MainProcessManager {
       return;
     }
     if (this.createTray()) {
+      // True "hide to tray": the window leaves the taskbar and is only recoverable through our own code, so it is safe
+      // to track hidden/auto state and drive restore-on-crash and quit-on-normal-shutdown off it.
       this.window.hide();
+      this.isHiddenToTray = true;
+      this.autoHiddenAfterStartup = options?.auto ?? false;
     } else {
-      // No usable tray host - fall back to a normal minimize so the window stays reachable from the taskbar/Dock. We
-      // still track the hidden/auto state so the contract (restore-on-crash, quit-on-normal-shutdown) holds; only the
-      // presentation degrades from "hidden to tray" to "minimized".
+      // No usable tray host - degrade to a plain minimize. Crucially we do NOT set the hidden/auto flags: a minimized
+      // window is reachable from the taskbar/Dock and the user can restore it with no code of ours running, which would
+      // otherwise leave those flags stale-true forever (suppressing the close-confirmation and quitting a visible
+      // launcher). Minimizing without the flags keeps every gated behavior correct.
       this.window.minimize();
     }
-    this.isHiddenToTray = true;
-    this.autoHiddenAfterStartup = options?.auto ?? false;
   };
 
   /**
@@ -407,13 +415,15 @@ export class MainProcessManager {
    * single-instance relaunch and the macOS Dock/activate handlers would silently do nothing, leaving no route back.
    */
   focusOrRestore = (): void => {
-    if (this.isHiddenToTray) {
-      this.showFromTray();
-      return;
-    }
     const window = this.window;
+    // Check for a gone window FIRST. If the launcher was closed (desktop mode keeps Invoke's window alive), recreate it -
+    // this must win over the tray branch, since showFromTray() gives up on a null window and would leave no route back.
     if (!window || window.isDestroyed()) {
       this.createWindow();
+      return;
+    }
+    if (this.isHiddenToTray) {
+      this.showFromTray();
       return;
     }
     if (window.isMinimized()) {

--- a/src/main/updater.ts
+++ b/src/main/updater.ts
@@ -10,7 +10,7 @@ autoUpdater.logger = console;
 autoUpdater.autoDownload = false;
 // autoUpdater.forceDevUpdateConfig = true;
 
-export const checkForUpdates = async (mainWindow: BrowserWindow) => {
+export const checkForUpdates = async (mainWindow: BrowserWindow, ensureVisible?: () => void) => {
   try {
     autoUpdater.allowPrerelease = store.get('optInToLauncherPrereleases');
     const updateCheckResult = await autoUpdater.checkForUpdates();
@@ -44,12 +44,18 @@ export const checkForUpdates = async (mainWindow: BrowserWindow) => {
     try {
       await autoUpdater.downloadUpdate();
     } catch {
+      // Make sure the launcher is visible - it may have been hidden to the tray while the download ran.
+      ensureVisible?.();
       dialog.showMessageBox(mainWindow, {
         type: 'error',
         title: 'Update Download Error',
         message: 'An error occurred while downloading the update. Please try again later.',
       });
     }
+
+    // The download can take a while, during which the launcher may have auto-hidden to the tray. Bring it back so this
+    // blocking prompt is actually visible and reachable before we quit to install.
+    ensureVisible?.();
 
     await dialog.showMessageBox(mainWindow, {
       type: 'info',

--- a/src/main/updater.ts
+++ b/src/main/updater.ts
@@ -1,3 +1,4 @@
+import type { BrowserWindow } from 'electron';
 import { dialog } from 'electron';
 import electronUpdater from 'electron-updater';
 
@@ -9,7 +10,7 @@ autoUpdater.logger = console;
 autoUpdater.autoDownload = false;
 // autoUpdater.forceDevUpdateConfig = true;
 
-export const checkForUpdates = async () => {
+export const checkForUpdates = async (mainWindow: BrowserWindow) => {
   try {
     autoUpdater.allowPrerelease = store.get('optInToLauncherPrereleases');
     const updateCheckResult = await autoUpdater.checkForUpdates();
@@ -29,10 +30,10 @@ export const checkForUpdates = async () => {
       'The update will be downloaded in the background. You will be notified when the download is complete and the update is ready to install.',
     ].join('\n');
 
-    // These dialogs are intentionally not parented to the launcher window. The launcher can be hidden to the tray (or
-    // minimized) at any point during the unbounded update check/download, and a window-modal dialog attached to a hidden
-    // window is unreachable - the user could never click "Restart and Install". Top-level dialogs are always visible.
-    const { response } = await dialog.showMessageBox({
+    // These dialogs are parented to the launcher window so they are modal to it while it is visible. If the launcher has
+    // been hidden to the tray by auto-hide, Electron degrades a dialog with a non-shown parent to an independent
+    // top-level window, so it stays reachable either way.
+    const { response } = await dialog.showMessageBox(mainWindow, {
       type: 'question',
       title: 'Update Available',
       message,
@@ -46,7 +47,7 @@ export const checkForUpdates = async () => {
     try {
       await autoUpdater.downloadUpdate();
     } catch {
-      await dialog.showMessageBox({
+      await dialog.showMessageBox(mainWindow, {
         type: 'error',
         title: 'Update Download Error',
         message: 'An error occurred while downloading the update. Please try again later.',
@@ -54,7 +55,7 @@ export const checkForUpdates = async () => {
       return;
     }
 
-    await dialog.showMessageBox({
+    await dialog.showMessageBox(mainWindow, {
       type: 'info',
       title: 'Update Downloaded',
       message: 'Update downloaded and ready to install.',

--- a/src/main/updater.ts
+++ b/src/main/updater.ts
@@ -1,4 +1,3 @@
-import type { BrowserWindow } from 'electron';
 import { dialog } from 'electron';
 import electronUpdater from 'electron-updater';
 
@@ -10,7 +9,7 @@ autoUpdater.logger = console;
 autoUpdater.autoDownload = false;
 // autoUpdater.forceDevUpdateConfig = true;
 
-export const checkForUpdates = async (mainWindow: BrowserWindow, ensureVisible?: () => void) => {
+export const checkForUpdates = async () => {
   try {
     autoUpdater.allowPrerelease = store.get('optInToLauncherPrereleases');
     const updateCheckResult = await autoUpdater.checkForUpdates();
@@ -30,7 +29,10 @@ export const checkForUpdates = async (mainWindow: BrowserWindow, ensureVisible?:
       'The update will be downloaded in the background. You will be notified when the download is complete and the update is ready to install.',
     ].join('\n');
 
-    const { response } = await dialog.showMessageBox(mainWindow, {
+    // These dialogs are intentionally not parented to the launcher window. The launcher can be hidden to the tray (or
+    // minimized) at any point during the unbounded update check/download, and a window-modal dialog attached to a hidden
+    // window is unreachable - the user could never click "Restart and Install". Top-level dialogs are always visible.
+    const { response } = await dialog.showMessageBox({
       type: 'question',
       title: 'Update Available',
       message,
@@ -44,9 +46,7 @@ export const checkForUpdates = async (mainWindow: BrowserWindow, ensureVisible?:
     try {
       await autoUpdater.downloadUpdate();
     } catch {
-      // Make sure the launcher is visible - it may have been hidden to the tray while the download ran.
-      ensureVisible?.();
-      await dialog.showMessageBox(mainWindow, {
+      await dialog.showMessageBox({
         type: 'error',
         title: 'Update Download Error',
         message: 'An error occurred while downloading the update. Please try again later.',
@@ -54,11 +54,7 @@ export const checkForUpdates = async (mainWindow: BrowserWindow, ensureVisible?:
       return;
     }
 
-    // The download can take a while, during which the launcher may have auto-hidden to the tray. Bring it back so this
-    // blocking prompt is actually visible and reachable before we quit to install.
-    ensureVisible?.();
-
-    await dialog.showMessageBox(mainWindow, {
+    await dialog.showMessageBox({
       type: 'info',
       title: 'Update Downloaded',
       message: 'Update downloaded and ready to install.',

--- a/src/main/util.ts
+++ b/src/main/util.ts
@@ -471,14 +471,14 @@ export const manageWindowSize = (
     }
   }
 
-  // Save window size and position when it is closed and clear the event listener
+  // Save window size and position on close. We intentionally do not remove this listener: a close may be prevented
+  // (e.g. by a confirmation dialog), and we still want to persist the latest bounds when the window is eventually closed.
   const handleClose = () => {
     setWindowProps({
       bounds: window.getBounds(),
       isMaximized: window.isMaximized(),
       isFullScreen: window.isFullScreen(),
     });
-    window.off('close', handleClose);
   };
 
   window.on('close', handleClose);

--- a/src/renderer/features/Banner/Banner.tsx
+++ b/src/renderer/features/Banner/Banner.tsx
@@ -6,6 +6,7 @@ import { assert } from 'tsafe';
 
 import { BannerInvokeLogoTag } from '@/renderer/features/Banner/BannerInvokeLogoTag';
 import { $launcherVersion } from '@/renderer/features/Banner/state';
+import { HideToTrayButton } from '@/renderer/features/SettingsModal/HideToTrayButton';
 import { SettingsModalOpenButton } from '@/renderer/features/SettingsModal/SettingsModalOpenButton';
 
 const MIN_PROBABILITY = 0.2;
@@ -82,6 +83,7 @@ export const Banner = memo(() => {
         )}
       </GridItem>
       <SettingsModalOpenButton position="absolute" insetBlockStart={3} insetInlineStart={3} />
+      <HideToTrayButton position="absolute" insetBlockStart={3} insetInlineStart={12} />
     </Grid>
   );
 });

--- a/src/renderer/features/Banner/Banner.tsx
+++ b/src/renderer/features/Banner/Banner.tsx
@@ -83,7 +83,7 @@ export const Banner = memo(() => {
         )}
       </GridItem>
       <SettingsModalOpenButton position="absolute" insetBlockStart={3} insetInlineStart={3} />
-      <HideToTrayButton position="absolute" insetBlockStart={3} insetInlineStart={12} />
+      <HideToTrayButton position="absolute" insetBlockStart={3} insetInlineStart={13} />
     </Grid>
   );
 });

--- a/src/renderer/features/SettingsModal/HideToTrayButton.tsx
+++ b/src/renderer/features/SettingsModal/HideToTrayButton.tsx
@@ -1,0 +1,25 @@
+import type { IconButtonProps } from '@invoke-ai/ui-library';
+import { IconButton } from '@invoke-ai/ui-library';
+import { memo, useCallback } from 'react';
+import { PiArrowLineDownBold } from 'react-icons/pi';
+
+import { emitter } from '@/renderer/services/ipc';
+
+export const HideToTrayButton = memo((props: Omit<IconButtonProps, 'aria-label'>) => {
+  const onClick = useCallback(() => {
+    emitter.invoke('main-process:hide-to-tray');
+  }, []);
+  return (
+    <IconButton
+      aria-label="Minimize to tray"
+      tooltip="Minimize to tray"
+      variant="link"
+      minW={10}
+      minH={10}
+      onClick={onClick}
+      icon={<PiArrowLineDownBold />}
+      {...props}
+    />
+  );
+});
+HideToTrayButton.displayName = 'HideToTrayButton';

--- a/src/renderer/features/SettingsModal/SettingsModal.tsx
+++ b/src/renderer/features/SettingsModal/SettingsModal.tsx
@@ -14,6 +14,7 @@ import {
 import { useStore } from '@nanostores/react';
 import { memo, useCallback } from 'react';
 
+import { SettingsModalHideLauncherAfterStartup } from '@/renderer/features/SettingsModal/SettingsModalHideLauncherAfterStartup';
 import { SettingsModalInvokeNotifyForPrereleaseUpdates } from '@/renderer/features/SettingsModal/SettingsModalInvokeNotifyForPrereleaseUpdates';
 import { SettingsModalInvokeServerMode } from '@/renderer/features/SettingsModal/SettingsModalInvokeServerMode';
 import { SettingsModalOptInToLauncherPrereleases } from '@/renderer/features/SettingsModal/SettingsModalOptInToLauncherPrereleases';
@@ -35,6 +36,8 @@ export const SettingsModal = memo(() => {
         <ModalCloseButton />
         <ModalBody as={Flex} flexDir="column" gap={4} w="full" h="full" minH={32}>
           <SettingsModalInvokeServerMode />
+          <Divider />
+          <SettingsModalHideLauncherAfterStartup />
           <Divider />
           <SettingsModalInvokeNotifyForPrereleaseUpdates />
           <Divider />

--- a/src/renderer/features/SettingsModal/SettingsModalHideLauncherAfterStartup.tsx
+++ b/src/renderer/features/SettingsModal/SettingsModalHideLauncherAfterStartup.tsx
@@ -1,0 +1,26 @@
+import { Checkbox, Flex, FormControl, FormHelperText, FormLabel } from '@invoke-ai/ui-library';
+import { useStore } from '@nanostores/react';
+import { memo, useCallback } from 'react';
+
+import { persistedStoreApi } from '@/renderer/services/store';
+
+export const SettingsModalHideLauncherAfterStartup = memo(() => {
+  const { hideLauncherAfterStartup } = useStore(persistedStoreApi.$atom);
+  const onChange = useCallback(() => {
+    persistedStoreApi.setKey('hideLauncherAfterStartup', !persistedStoreApi.$atom.get().hideLauncherAfterStartup);
+  }, []);
+
+  return (
+    <FormControl orientation="vertical">
+      <Flex w="full" alignItems="center" justifyContent="space-between">
+        <FormLabel>Hide Launcher After Startup</FormLabel>
+        <Checkbox isChecked={hideLauncherAfterStartup} onChange={onChange} />
+      </Flex>
+      <FormHelperText>
+        Once Invoke has started, hide the launcher to the system tray. Click the tray icon to bring it back to view the
+        logs. The launcher reappears if Invoke crashes and closes when Invoke shuts down normally.
+      </FormHelperText>
+    </FormControl>
+  );
+});
+SettingsModalHideLauncherAfterStartup.displayName = 'SettingsModalHideLauncherAfterStartup';

--- a/src/renderer/features/SettingsModal/SettingsModalHideLauncherAfterStartup.tsx
+++ b/src/renderer/features/SettingsModal/SettingsModalHideLauncherAfterStartup.tsx
@@ -18,7 +18,8 @@ export const SettingsModalHideLauncherAfterStartup = memo(() => {
       </Flex>
       <FormHelperText>
         Once Invoke has started, hide the launcher to the system tray. Click the tray icon to bring it back to view the
-        logs. The launcher reappears if Invoke crashes and closes when Invoke shuts down normally.
+        logs. The launcher reappears if Invoke crashes and closes when Invoke shuts down normally. On systems without a
+        system tray, the launcher is minimized instead and these automatic behaviors are skipped.
       </FormHelperText>
     </FormControl>
   );

--- a/src/renderer/services/store.ts
+++ b/src/renderer/services/store.ts
@@ -8,6 +8,7 @@ const getDefaults = (): StoreData => ({
   serverMode: false,
   notifyForPrereleaseUpdates: true,
   optInToLauncherPrereleases: false,
+  hideLauncherAfterStartup: false,
 });
 
 /**

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -52,6 +52,11 @@ export type StoreData = {
   launcherWindowProps?: WindowProps;
   appWindowProps?: WindowProps;
   optInToLauncherPrereleases: boolean;
+  /**
+   * When enabled, the launcher window is hidden to the system tray once Invoke has started successfully. It is restored
+   * again if Invoke errors or its window crashes, and the launcher quits entirely when Invoke shuts down normally.
+   */
+  hideLauncherAfterStartup: boolean;
 };
 
 // The electron store uses JSON schema to validate its data.
@@ -94,6 +99,10 @@ export const schema: Schema<StoreData> = {
   launcherWindowProps: winSizePropsSchema,
   appWindowProps: winSizePropsSchema,
   optInToLauncherPrereleases: {
+    type: 'boolean',
+    default: false,
+  },
+  hideLauncherAfterStartup: {
     type: 'boolean',
     default: false,
   },
@@ -295,6 +304,10 @@ type MainProcessIpcEvents = Namespaced<
   {
     'get-status': () => WithTimestamp<MainProcessStatus>;
     exit: () => void;
+    /**
+     * Hide the launcher window to the system tray. A tray icon is shown, from which the launcher can be restored.
+     */
+    'hide-to-tray': () => void;
   }
 >;
 

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -55,6 +55,9 @@ export type StoreData = {
   /**
    * When enabled, the launcher window is hidden to the system tray once Invoke has started successfully. It is restored
    * again if Invoke errors or its window crashes, and the launcher quits entirely when Invoke shuts down normally.
+   *
+   * These automatic behaviors require a working system tray. On hosts where no tray is available, the launcher is
+   * minimized instead and the auto-restore/auto-quit behaviors are skipped.
    */
   hideLauncherAfterStartup: boolean;
 };

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,1 +1,7 @@
 /// <reference types="vite/client" />
+
+// electron-vite resolves `?asset` imports in the main process to the runtime file path.
+declare module '*?asset' {
+  const src: string;
+  export default src;
+}


### PR DESCRIPTION
Closes #52
Closes #152 

Adds an opt-in "Hide Launcher After Startup" setting. When enabled, the launcher window hides to the system tray once Invoke has started, keeping the desktop uncluttered while Invoke runs (works in server mode too).

- Add a Tray icon with a context menu (Show Launcher / Quit); clicking the icon restores the launcher window.
- Auto-hide the launcher on the Invoke "running" status; restore it if Invoke errors or its window crashes; quit the app entirely when Invoke shuts down normally while the launcher was hidden.
- Add a manual "Minimize to tray" button to the banner, backed by a new main-process:hide-to-tray IPC channel.
- Confirm before closing the launcher window while Invoke is still running.
- Persist window bounds even after a prevented/cancelled close.