### PR TITLE
chore: bump version to v1.8.2-rc.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "invoke-community-edition",
-  "version": "1.8.1",
+  "version": "1.8.2-rc.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "invoke-community-edition",
-      "version": "1.8.1",
+      "version": "1.8.2-rc.1",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "invoke-community-edition",
   "productName": "Invoke Community Edition",
-  "version": "1.8.1",
+  "version": "1.8.2-rc.1",
   "description": "Invoke Community Edition",
   "main": "out/main/index.js",
   "engines": {


### PR DESCRIPTION
## Summary

Version bump 1.8.1 → 1.8.2-rc.1, per RELEASE.md step 1.

Prerelease to validate the new OSSign Windows signing path (90844dd, cfd5112) and the bootstrap-install changes (316ee1a, 030fd72) before the final 1.8.2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)