### PR TITLE
chore: bump version to v1.8.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "invoke-community-edition",
-  "version": "1.8.2-rc.1",
+  "version": "1.8.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "invoke-community-edition",
-      "version": "1.8.2-rc.1",
+      "version": "1.8.2",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "invoke-community-edition",
   "productName": "Invoke Community Edition",
-  "version": "1.8.2-rc.1",
+  "version": "1.8.2",
   "description": "Invoke Community Edition",
   "main": "out/main/index.js",
   "engines": {


### PR DESCRIPTION
Graduates `v1.8.2-rc.1` to the final `v1.8.2`. No functional changes — `npm run version patch` only touches `package.json` and `package-lock.json`.

The release candidate has been out since 2026-07-12 with no reported issues, so 1.8.2 ships the rc content unchanged, plus the CI-only artifact-version guard from #144.

🤖 Generated with [Claude Code](https://claude.com/claude-code)