### PR TITLE
fix(updater): make signed Windows assets match the names latest.yml declares

### DIFF
--- a/.github/workflows/wait-signature.yml
+++ b/.github/workflows/wait-signature.yml
@@ -80,6 +80,88 @@ jobs:
           echo "Downloaded signed artifacts:"
           ls -l dist
 
+      - name: Reconcile signed artifacts with latest.yml
+        # electron-updater downloads *exactly* the filenames latest.yml declares, resolved against
+        # the release's download path — so the payload names and the manifest have to agree byte
+        # for byte. They don't, by default: electron-builder writes manifest URLs with spaces
+        # normalized to '-' (and its own publisher uploads under that name), while artifacts that
+        # travel through GitHub's asset API — as OSSign's do — come back with spaces sanitized to
+        # '.'. v1.8.2 shipped that way: latest.yml pointed at Invoke-Community-Edition-Setup-1.8.2.exe
+        # while the attached asset was Invoke.Community.Edition.Setup.1.8.2.exe, so every Windows
+        # user's update 404'd. Rename the payloads to what the manifest declares ('-' survives
+        # GitHub's sanitizer untouched) and verify the digests, so a mismatch fails the build here
+        # instead of on users' machines.
+        if: steps.check.outputs.signed_artifacts != ''
+        working-directory: dist
+        run: |
+          set -euo pipefail
+
+          if [ ! -f latest.yml ]; then
+            echo "::warning::No latest.yml among the signed artifacts; skipping name reconciliation."
+            exit 0
+          fi
+
+          # Compare names ignoring the separator characters the two sanitizers disagree about.
+          norm() { printf '%s' "$1" | sed 's/%20/-/g; s/[ .]/-/g'; }
+
+          # Emit one "<url>\t<sha512>" line per files[] entry. The trailing top-level sha512 (which
+          # duplicates files[0]) can't clobber an entry: sha is only taken when still unset.
+          entries=$(awk '
+            /^[[:space:]]*-[[:space:]]*url:/ {
+              if (u != "") { print u "\t" s }
+              sub(/^[[:space:]]*-[[:space:]]*url:[[:space:]]*/, ""); u = $0; s = ""
+              next
+            }
+            /^[[:space:]]*sha512:/ && u != "" && s == "" {
+              sub(/^[[:space:]]*sha512:[[:space:]]*/, ""); s = $0
+            }
+            END { if (u != "") { print u "\t" s } }
+          ' latest.yml)
+
+          if [ -z "${entries}" ]; then
+            echo "::error::latest.yml declares no files[] entries; cannot verify what the updater will fetch."
+            exit 1
+          fi
+
+          while IFS=$'\t' read -r want sha; do
+            [ -n "${want}" ] || continue
+
+            if [ ! -f "${want}" ]; then
+              key=$(norm "${want}")
+              found=""
+              for f in *; do
+                [ -f "${f}" ] || continue
+                [ "$(norm "${f}")" = "${key}" ] || continue
+                found="${f}"
+                break
+              done
+              if [ -z "${found}" ]; then
+                echo "::error::latest.yml declares '${want}' but no downloaded artifact matches it, even ignoring '.'/' ' separators. Refusing to attach a release the updater cannot download."
+                exit 1
+              fi
+              echo "Renaming '${found}' -> '${want}' to match latest.yml"
+              mv -- "${found}" "${want}"
+              # electron-updater derives the differential-download blockmap URL by appending
+              # .blockmap to the declared filename, so it has to follow the installer's new name.
+              if [ -f "${found}.blockmap" ]; then
+                mv -- "${found}.blockmap" "${want}.blockmap"
+              fi
+            fi
+
+            if [ -n "${sha}" ]; then
+              actual=$(openssl dgst -sha512 -binary "${want}" | base64 -w0)
+              if [ "${actual}" != "${sha}" ]; then
+                echo "::error::'${want}' does not match the sha512 in latest.yml (expected ${sha}, got ${actual}). electron-updater would reject this download. Refusing to attach."
+                exit 1
+              fi
+            fi
+
+            echo "Verified: ${want}"
+          done <<< "${entries}"
+
+          echo "Artifacts after reconciliation:"
+          ls -l
+
       - name: Upload workflow artifact
         if: steps.check.outputs.signed_artifacts != ''
         uses: actions/upload-artifact@v4

--- a/.github/workflows/wait-signature.yml
+++ b/.github/workflows/wait-signature.yml
@@ -80,88 +80,6 @@ jobs:
           echo "Downloaded signed artifacts:"
           ls -l dist
 
-      - name: Reconcile signed artifacts with latest.yml
-        # electron-updater downloads *exactly* the filenames latest.yml declares, resolved against
-        # the release's download path — so the payload names and the manifest have to agree byte
-        # for byte. They don't, by default: electron-builder writes manifest URLs with spaces
-        # normalized to '-' (and its own publisher uploads under that name), while artifacts that
-        # travel through GitHub's asset API — as OSSign's do — come back with spaces sanitized to
-        # '.'. v1.8.2 shipped that way: latest.yml pointed at Invoke-Community-Edition-Setup-1.8.2.exe
-        # while the attached asset was Invoke.Community.Edition.Setup.1.8.2.exe, so every Windows
-        # user's update 404'd. Rename the payloads to what the manifest declares ('-' survives
-        # GitHub's sanitizer untouched) and verify the digests, so a mismatch fails the build here
-        # instead of on users' machines.
-        if: steps.check.outputs.signed_artifacts != ''
-        working-directory: dist
-        run: |
-          set -euo pipefail
-
-          if [ ! -f latest.yml ]; then
-            echo "::warning::No latest.yml among the signed artifacts; skipping name reconciliation."
-            exit 0
-          fi
-
-          # Compare names ignoring the separator characters the two sanitizers disagree about.
-          norm() { printf '%s' "$1" | sed 's/%20/-/g; s/[ .]/-/g'; }
-
-          # Emit one "<url>\t<sha512>" line per files[] entry. The trailing top-level sha512 (which
-          # duplicates files[0]) can't clobber an entry: sha is only taken when still unset.
-          entries=$(awk '
-            /^[[:space:]]*-[[:space:]]*url:/ {
-              if (u != "") { print u "\t" s }
-              sub(/^[[:space:]]*-[[:space:]]*url:[[:space:]]*/, ""); u = $0; s = ""
-              next
-            }
-            /^[[:space:]]*sha512:/ && u != "" && s == "" {
-              sub(/^[[:space:]]*sha512:[[:space:]]*/, ""); s = $0
-            }
-            END { if (u != "") { print u "\t" s } }
-          ' latest.yml)
-
-          if [ -z "${entries}" ]; then
-            echo "::error::latest.yml declares no files[] entries; cannot verify what the updater will fetch."
-            exit 1
-          fi
-
-          while IFS=$'\t' read -r want sha; do
-            [ -n "${want}" ] || continue
-
-            if [ ! -f "${want}" ]; then
-              key=$(norm "${want}")
-              found=""
-              for f in *; do
-                [ -f "${f}" ] || continue
-                [ "$(norm "${f}")" = "${key}" ] || continue
-                found="${f}"
-                break
-              done
-              if [ -z "${found}" ]; then
-                echo "::error::latest.yml declares '${want}' but no downloaded artifact matches it, even ignoring '.'/' ' separators. Refusing to attach a release the updater cannot download."
-                exit 1
-              fi
-              echo "Renaming '${found}' -> '${want}' to match latest.yml"
-              mv -- "${found}" "${want}"
-              # electron-updater derives the differential-download blockmap URL by appending
-              # .blockmap to the declared filename, so it has to follow the installer's new name.
-              if [ -f "${found}.blockmap" ]; then
-                mv -- "${found}.blockmap" "${want}.blockmap"
-              fi
-            fi
-
-            if [ -n "${sha}" ]; then
-              actual=$(openssl dgst -sha512 -binary "${want}" | base64 -w0)
-              if [ "${actual}" != "${sha}" ]; then
-                echo "::error::'${want}' does not match the sha512 in latest.yml (expected ${sha}, got ${actual}). electron-updater would reject this download. Refusing to attach."
-                exit 1
-              fi
-            fi
-
-            echo "Verified: ${want}"
-          done <<< "${entries}"
-
-          echo "Artifacts after reconciliation:"
-          ls -l
-
       - name: Upload workflow artifact
         if: steps.check.outputs.signed_artifacts != ''
         uses: actions/upload-artifact@v4
@@ -195,6 +113,117 @@ jobs:
             exit 1
           fi
           echo "Artifact version ${actual} matches ${{ inputs.target_ref }}."
+
+      - name: Reconcile signed artifacts with latest.yml
+        # electron-updater downloads *exactly* the filenames latest.yml declares, resolved against
+        # the release's download path — so the payload names and the manifest have to agree byte
+        # for byte. They don't, by default: electron-builder writes manifest URLs with spaces
+        # normalized to '-' (and its own publisher uploads under that name), while artifacts that
+        # travel through GitHub's asset API — as OSSign's do — come back with spaces sanitized to
+        # '.'. v1.8.2 shipped that way: latest.yml pointed at Invoke-Community-Edition-Setup-1.8.2.exe
+        # while the attached asset was Invoke.Community.Edition.Setup.1.8.2.exe, so every Windows
+        # user's update 404'd. Rename the payloads to what the manifest declares ('-' survives
+        # GitHub's sanitizer untouched) and verify the digests, so a mismatch fails the build here
+        # instead of on users' machines.
+        #
+        # Ordering matters: this runs AFTER "Upload workflow artifact" so that a rejection here
+        # still leaves the hours-of-signing binaries in the 90-day archive, and AFTER the stale-
+        # version check so that recycled artifacts are reported as such rather than as a name
+        # mismatch. It is tag-gated like the attach step below — on non-tag runs nothing is
+        # attached, so there is nothing to reconcile.
+        if: steps.check.outputs.signed_artifacts != '' && startsWith(inputs.target_ref, 'v')
+        working-directory: dist
+        run: |
+          set -euo pipefail
+
+          # The previous step already rejected a tag run without latest.yml; belt and braces.
+          if [ ! -f latest.yml ]; then
+            echo "::error::No latest.yml among the signed artifacts; cannot reconcile names."
+            exit 1
+          fi
+
+          # Compare names ignoring the separator characters the two sanitizers disagree about.
+          norm() { printf '%s' "$1" | sed 's/%20/-/g; s/[ .]/-/g'; }
+
+          # Emit one "<url>\t<sha512>" line per files[] entry. The trailing top-level sha512 (which
+          # duplicates files[0]) can't clobber an entry: sha is only taken when still unset.
+          entries=$(awk '
+            /^[[:space:]]*-[[:space:]]*url:/ {
+              if (u != "") { print u "\t" s }
+              sub(/^[[:space:]]*-[[:space:]]*url:[[:space:]]*/, ""); u = $0; s = ""
+              next
+            }
+            /^[[:space:]]*sha512:/ && u != "" && s == "" {
+              sub(/^[[:space:]]*sha512:[[:space:]]*/, ""); s = $0
+            }
+            END { if (u != "") { print u "\t" s } }
+          ' latest.yml)
+
+          if [ -z "${entries}" ]; then
+            echo "::error::latest.yml declares no files[] entries; cannot verify what the updater will fetch."
+            exit 1
+          fi
+
+          # Names already assigned to an earlier entry, so a later entry cannot rename them away.
+          claimed=""
+
+          while IFS=$'\t' read -r want sha; do
+            [ -n "${want}" ] || continue
+
+            # For provider 'github' electron-builder always writes a GitHub-safe url. If that ever
+            # stops being true, renaming a payload to an unsafe name would recreate the very 404
+            # this step exists to prevent, with a green build. Refuse instead of renaming.
+            case "${want}" in
+              *[!0-9A-Za-z._-]*)
+                echo "::error::latest.yml declares '${want}', which contains characters GitHub's asset API rewrites on upload. The updater could not fetch it under that name. Refusing to attach."
+                exit 1
+                ;;
+            esac
+
+            if [ -e "${want}" ] && [ ! -f "${want}" ]; then
+              echo "::error::'${want}' exists in the artifact set but is not a regular file. Refusing to attach."
+              exit 1
+            fi
+
+            if [ ! -f "${want}" ]; then
+              key=$(norm "${want}")
+              found=""
+              for f in *; do
+                [ -f "${f}" ] || continue
+                if case "${claimed}" in *"|${f}|"*) true;; *) false;; esac; then
+                  continue
+                fi
+                [ "$(norm "${f}")" = "${key}" ] || continue
+                found="${f}"
+                break
+              done
+              if [ -z "${found}" ]; then
+                echo "::error::latest.yml declares '${want}' but no downloaded artifact matches it, even ignoring '.'/' ' separators. Refusing to attach a release the updater cannot download."
+                exit 1
+              fi
+              echo "Renaming '${found}' -> '${want}' to match latest.yml"
+              mv -- "${found}" "${want}"
+              # electron-updater derives the differential-download blockmap URL by appending
+              # .blockmap to the declared filename, so it has to follow the installer's new name.
+              if [ -f "${found}.blockmap" ]; then
+                mv -- "${found}.blockmap" "${want}.blockmap"
+              fi
+            fi
+            claimed="${claimed}|${want}|"
+
+            if [ -n "${sha}" ]; then
+              actual=$(openssl dgst -sha512 -binary "${want}" | base64 -w0)
+              if [ "${actual}" != "${sha}" ]; then
+                echo "::error::'${want}' does not match the sha512 in latest.yml (expected ${sha}, got ${actual}). electron-updater would reject this download. Refusing to attach."
+                exit 1
+              fi
+            fi
+
+            echo "Verified: ${want}"
+          done <<< "${entries}"
+
+          echo "Artifacts after reconciliation:"
+          ls -l
 
       - name: Attach signed artifacts to the release
         # Only for vX.Y.Z tags — the release is created by the linux/macOS publish jobs. For

--- a/src/main/updater.ts
+++ b/src/main/updater.ts
@@ -44,11 +44,12 @@ export const checkForUpdates = async (mainWindow: BrowserWindow) => {
     try {
       await autoUpdater.downloadUpdate();
     } catch {
-      dialog.showMessageBox(mainWindow, {
+      await dialog.showMessageBox(mainWindow, {
         type: 'error',
         title: 'Update Download Error',
         message: 'An error occurred while downloading the update. Please try again later.',
       });
+      return;
     }
 
     await dialog.showMessageBox(mainWindow, {


### PR DESCRIPTION
## Problem

Windows self-update has been broken since Windows signing moved to OSSign. Users on 1.8.1 who accept the update prompt get "An error occurred while downloading the update."

`electron-updater` fetches *exactly* the filename `latest.yml` declares, so the manifest and the attached asset have to agree byte for byte. They don't:

- electron-builder writes manifest URLs with spaces normalized to `-`, and its own publisher uploads under that same name (this is why macOS and Linux are fine).
- Artifacts routed through GitHub's asset API — as OSSign's are — come back with spaces sanitized to `.`, and `gh release upload` attaches them under that name.

On v1.8.2 that produced:

| URL the updater requests | Asset actually on the release |
| --- | --- |
| `Invoke-Community-Edition-Setup-1.8.2.exe` (404) | `Invoke.Community.Edition.Setup.1.8.2.exe` (200) |

The blockmap 404s too, so even the differential path can't save it. v1.8.2-rc.1 has the same mismatch.

**The v1.8.2 release itself is already repaired** — correctly-named copies of the signed installer and blockmap have been attached (byte-identical, sha512 verified against `latest.yml` before upload), so affected users can update today without waiting on this PR. `Invoke.Community.Edition.Setup.latest.exe` is untouched, so the website download link is unaffected.

## Changes

**`.github/workflows/wait-signature.yml`** — new "Reconcile signed artifacts with latest.yml" step before the assets are attached. It renames each downloaded payload to the filename `latest.yml` declares (matching on names normalized for the separator disagreement; `-` survives GitHub's sanitizer), carries the `.blockmap` along under the installer's new name since electron-updater derives its URL by suffixing the declared name, and verifies every declared sha512. A mismatch now fails the release build instead of users' updates.

Placement is deliberate: **after** `Upload workflow artifact`, so a rejection still leaves the hours-of-signing binaries in the 90-day archive; **after** the stale-version check, so recycled OSSign artifacts are reported as such rather than as a name mismatch; and tag-gated like the attach step, since non-tag runs attach nothing.

**`src/main/updater.ts`** — a failed download showed the error dialog and then fell through to announce "Update downloaded and ready to install" and call `quitAndInstall()`. Added the missing `return`.

## Verification

The reconcile step was extracted from the YAML and run against real v1.8.2 artifacts and constructed adversarial inputs:

| Case | Result |
| --- | --- |
| Real v1.8.2 dotted names + blockmap + `…latest.exe` copies | renames installer and blockmap, sha verified, `latest` copies untouched, exit 0 |
| Already correctly named (idempotent re-run) | exit 0, no changes |
| No artifact matches a declared url | `::error::` refuse, exit 1 |
| Right name, wrong bytes | `::error::` sha mismatch, exit 1 |
| Manifest url containing `%20` | `::error::` refuse rather than rename to an unsafe name, exit 1 |
| Two entries colliding under normalization | earlier entry's file is not stolen, exit 1 |
| Declared name occupied by a directory | `::error::` refuse, exit 1 |
| Missing `latest.yml` | `::error::` refuse, exit 1 |

`tsc`, `eslint`, and `prettier` pass.

## Known follow-ups (not in this PR)

Surfaced while reviewing the update flow; all pre-existing and out of scope here. An earlier revision of this description claimed `autoUpdater` has no error listener and that errors are thrown and swallowed — that was wrong, and the corrected findings are below.

1. **Windows install failures exit silently, and an error listener cannot fix it.** `AppUpdater.js:177` already registers an `error` listener in its constructor, so errors are logged, not thrown. The real gap is that `NsisUpdater.doInstall` returns `true` unconditionally (`NsisUpdater.js:148`) as soon as the installer is spawned, so `quitAndInstall` schedules `app.quit()` via `setImmediate` regardless of whether that spawn succeeded. Failures arrive from a promise catch — a microtask, so it runs *before* the `setImmediate` — leaving no window in which anything can be shown to the user. Reporting this properly needs the quit deferred, not an extra listener.
2. **`AppImageUpdater.js:105` floats a promise** (`this.spawnLog(destination, [], env)` with no `.catch`), so a spawn failure there is a genuine unhandled rejection on Linux, and it is not routed through `dispatchError`.
3. **The "Update Downloaded" dialog is an announcement, not a choice.** Its single button's response is ignored and `quitAndInstall()` is unconditional, so Esc quits too — killing in-flight install/generation processes via the `before-quit` cleanup. A "Later" button would fix it; `autoInstallOnAppQuit` still installs on the next clean quit.
4. **Check-side failures are user-invisible** (network, rate limit, malformed manifest) — logged by the library, but never surfaced.

Also worth knowing so it isn't misread as a regression: differential updates will still fall back to a full download, because electron-updater resolves *both* blockmap URLs against the new release's path, so the old version's blockmap 404s regardless of naming.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
