### PR TITLE
fix: prevent banner action buttons from overlapping

### DIFF
--- a/src/renderer/features/Banner/Banner.tsx
+++ b/src/renderer/features/Banner/Banner.tsx
@@ -82,8 +82,10 @@ export const Banner = memo(() => {
           </Button>
         )}
       </GridItem>
-      <SettingsModalOpenButton position="absolute" insetBlockStart={3} insetInlineStart={3} />
-      <HideToTrayButton position="absolute" insetBlockStart={3} insetInlineStart={13} />
+      <Flex position="absolute" insetBlockStart={3} insetInlineStart={3} gap={2}>
+        <SettingsModalOpenButton />
+        <HideToTrayButton />
+      </Flex>
     </Grid>
   );
 });


### PR DESCRIPTION
Fixes the overlap between the Settings and Minimize to tray buttons by placing them in a shared `Flex` container with an explicit gap.
Closes  #154